### PR TITLE
Feature/fix removerter

### DIFF
--- a/include/removert/Removerter.h
+++ b/include/removert/Removerter.h
@@ -5,131 +5,140 @@
 class Removerter : public RosParamServer
 {
 private:
-    
-    ros::Subscriber subLaserCloud; // TODO, for real-time integration (later)
+  ros::Subscriber subLaserCloud;  // TODO, for real-time integration (later)
 
-    const float kFlagNoPOINT = 10000.0; // no point constant, 10000 has no meaning, but must be larger than the maximum scan range (e.g., 200 meters)
-    const float kValidDiffUpperBound = 200.0; // must smaller than kFlagNoPOINT
+  const float kFlagNoPOINT = 10000.0;  // no point constant, 10000 has no meaning, but must be larger than the maximum
+                                       // scan range (e.g., 200 meters)
+  const float kValidDiffUpperBound = 200.0;  // must smaller than kFlagNoPOINT
 
-    // Static sensitivity
-    int kNumKnnPointsToCompare;// static sensitivity (increase this value, less static structure will be removed at the scan-side removal stage)
-    float kScanKnnAndMapKnnAvgDiffThreshold; // static sensitivity (decrease this value, less static structure will be removed at the scan-side removal stage)
+  // Static sensitivity
+  int kNumKnnPointsToCompare;  // static sensitivity (increase this value, less static structure will be removed at the
+                               // scan-side removal stage)
+  float kScanKnnAndMapKnnAvgDiffThreshold;  // static sensitivity (decrease this value, less static structure will be
+                                            // removed at the scan-side removal stage)
 
-    std::vector<std::string> sequence_valid_scan_names_;
-    std::vector<std::string> sequence_valid_scan_paths_;
-    std::vector<pcl::PointCloud<PointType>::Ptr> scans_;
-    std::vector<pcl::PointCloud<PointType>::Ptr> scans_static_;
-    std::vector<pcl::PointCloud<PointType>::Ptr> scans_dynamic_;
+  std::vector<std::string> sequence_valid_scan_names_;
+  std::vector<std::string> sequence_valid_scan_paths_;
+  std::vector<pcl::PointCloud<PointType>::Ptr> scans_;
+  std::vector<pcl::PointCloud<PointType>::Ptr> scans_static_;
+  std::vector<pcl::PointCloud<PointType>::Ptr> scans_dynamic_;
 
-    std::string scan_static_save_dir_;
-    std::string scan_dynamic_save_dir_;
-    std::string map_static_save_dir_;
-    std::string map_dynamic_save_dir_;
-    
-    std::vector<Eigen::Matrix4d> scan_poses_;
-    std::vector<Eigen::Matrix4d> scan_inverse_poses_;
+  std::string scan_static_save_dir_;
+  std::string scan_dynamic_save_dir_;
+  std::string map_static_save_dir_;
+  std::string map_dynamic_save_dir_;
 
-    pcl::KdTreeFLANN<PointType>::Ptr kdtree_map_global_curr_;
-    pcl::KdTreeFLANN<PointType>::Ptr kdtree_scan_global_curr_;
+  std::vector<Eigen::Matrix4d> scan_poses_;
+  std::vector<Eigen::Matrix4d> scan_inverse_poses_;
 
-    pcl::PointCloud<PointType>::Ptr map_global_orig_;
+  pcl::KdTreeFLANN<PointType>::Ptr kdtree_map_global_curr_;
+  pcl::KdTreeFLANN<PointType>::Ptr kdtree_scan_global_curr_;
 
-    pcl::PointCloud<PointType>::Ptr map_global_curr_; // the M_i. i.e., removert is: M1 -> S1 + D1, D1 -> M2 , M2 -> S2 + D2 ... repeat ... 
-    pcl::PointCloud<PointType>::Ptr map_local_curr_;
+  pcl::PointCloud<PointType>::Ptr map_global_orig_;
 
-    pcl::PointCloud<PointType>::Ptr map_subset_global_curr_;
+  pcl::PointCloud<PointType>::Ptr map_global_curr_;  // the M_i. i.e., removert is: M1 -> S1 + D1, D1 -> M2 , M2 -> S2 +
+                                                     // D2 ... repeat ...
+  pcl::PointCloud<PointType>::Ptr map_local_curr_;
 
-    pcl::PointCloud<PointType>::Ptr map_global_curr_static_; // the S_i
-    pcl::PointCloud<PointType>::Ptr map_global_curr_dynamic_;  // the D_i
+  pcl::PointCloud<PointType>::Ptr map_subset_global_curr_;
 
-    pcl::PointCloud<PointType>::Ptr map_global_accumulated_static_; // TODO, the S_i after reverted
-    pcl::PointCloud<PointType>::Ptr map_global_accumulated_dynamic_;  // TODO, the D_i after reverted 
+  pcl::PointCloud<PointType>::Ptr map_global_curr_static_;   // the S_i
+  pcl::PointCloud<PointType>::Ptr map_global_curr_dynamic_;  // the D_i
 
-    std::vector<pcl::PointCloud<PointType>::Ptr> static_map_global_history_; // TODO
-    std::vector<pcl::PointCloud<PointType>::Ptr> dynamic_map_global_history_; // TODO
+  pcl::PointCloud<PointType>::Ptr map_global_accumulated_static_;   // TODO, the S_i after reverted
+  pcl::PointCloud<PointType>::Ptr map_global_accumulated_dynamic_;  // TODO, the D_i after reverted
 
-    float curr_res_alpha_; // just for tracking current status
+  std::vector<pcl::PointCloud<PointType>::Ptr> static_map_global_history_;   // TODO
+  std::vector<pcl::PointCloud<PointType>::Ptr> dynamic_map_global_history_;  // TODO
 
-    const int base_node_idx_ = 0;
+  float curr_res_alpha_;  // just for tracking current status
 
-    unsigned long kPauseTimeForClearStaticScanVisualization = 1000; // microsec
+  const int base_node_idx_ = 0;
 
-    // NOT recommend to use for under 5 million points map input (becausing not-using is just faster)
-    const bool kUseSubsetMapCloud = false; 
-    const float kBallSize = 80.0; // meter
+  unsigned long kPauseTimeForClearStaticScanVisualization = 1000;  // microsec
+
+  // NOT recommend to use for under 5 million points map input (becausing not-using is just faster)
+  const bool kUseSubsetMapCloud = false;
+  const float kBallSize = 80.0;  // meter
 
 public:
-    Removerter();
-    ~Removerter();
+  Removerter();
+  ~Removerter();
 
-    void cloudHandler(const sensor_msgs::PointCloud2ConstPtr& laserCloudMsg); // TODO (if removert run online)
+  void cloudHandler(const sensor_msgs::PointCloud2ConstPtr& laserCloudMsg);  // TODO (if removert run online)
 
-    void allocateMemory();
+  void allocateMemory();
 
-    void parseValidScanInfo();
-    void readValidScans();
+  void parseValidScanInfo();
+  void readValidScans();
 
-    void mergeScansWithinGlobalCoord( 
-            const std::vector<pcl::PointCloud<PointType>::Ptr>& _scans, 
-            const std::vector<Eigen::Matrix4d>& _scans_poses,
-            pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save );
-    void Downsampling(const pcl::PointCloud<PointType>::Ptr& _src, pcl::PointCloud<PointType>::Ptr& _to_save);
+  void mergeScansWithinGlobalCoord(const std::vector<pcl::PointCloud<PointType>::Ptr>& _scans,
+                                   const std::vector<Eigen::Matrix4d>& _scans_poses,
+                                   pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save);
+  void Downsampling(const pcl::PointCloud<PointType>::Ptr& _src, pcl::PointCloud<PointType>::Ptr& _to_save);
 
-    void savePCD(std::string file_name, pcl::PointCloud<PointType>::Ptr cloudIn);
+  void savePCD(std::string file_name, pcl::PointCloud<PointType>::Ptr cloudIn);
 
-    void makeGlobalMap();
+  void makeGlobalMap();
 
-    void run(void);
+  void run(void);
 
-    void removeOnce(float _res);
-    void revertOnce(float _res);
+  void removeOnce(float _res);
+  void revertOnce(float _res);
 
-    void saveCurrentStaticMapHistory(void); // the 0th element is a noisy (original input) (actually not static) map.
-    void saveCurrentDynamicMapHistory(void);
+  void saveCurrentStaticMapHistory(void);  // the 0th element is a noisy (original input) (actually not static) map.
+  void saveCurrentDynamicMapHistory(void);
 
-    void takeGlobalMapSubsetWithinBall( int _center_scan_idx );
-    void transformGlobalMapSubsetToLocal(int _base_scan_idx);
+  void takeGlobalMapSubsetWithinBall(int _center_scan_idx);
+  void transformGlobalMapSubsetToLocal(int _base_scan_idx);
 
-    void transformGlobalMapToLocal(int _base_scan_idx);
-    void transformGlobalMapToLocal(int _base_scan_idx, pcl::PointCloud<PointType>::Ptr& _map_local);
-    void transformGlobalMapToLocal(const pcl::PointCloud<PointType>::Ptr& _map_global, int _base_scan_idx, pcl::PointCloud<PointType>::Ptr& _map_local);
+  void transformGlobalMapToLocal(int _base_scan_idx);
+  void transformGlobalMapToLocal(int _base_scan_idx, pcl::PointCloud<PointType>::Ptr& _map_local);
+  void transformGlobalMapToLocal(const pcl::PointCloud<PointType>::Ptr& _map_global, int _base_scan_idx,
+                                 pcl::PointCloud<PointType>::Ptr& _map_local);
 
-    cv::Mat scan2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan, 
+  cv::Mat scan2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan,
                         const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25, lower 25), hfov = 360] */
                         const std::pair<int, int> _rimg_size);
-    std::pair<cv::Mat, cv::Mat> map2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan, 
-                        const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25, lower 25), hfov = 360] */
-                        const std::pair<int, int> _rimg_size);
+  std::pair<cv::Mat, cv::Mat> map2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan,
+                                           const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25, lower 25),
+                                                                                  hfov = 360] */
+                                           const std::pair<int, int> _rimg_size);
 
-    std::vector<int> calcDescrepancyAndParseDynamicPointIdx (const cv::Mat& _scan_rimg, const cv::Mat& _diff_rimg, const cv::Mat& _map_rimg_ptidx);
-    std::vector<int> calcDescrepancyAndParseDynamicPointIdxForEachScan( std::pair<int, int> _rimg_shape );
+  std::vector<int> calcDescrepancyAndParseDynamicPointIdx(const cv::Mat& _scan_rimg, const cv::Mat& _diff_rimg,
+                                                          const cv::Mat& _map_rimg_ptidx);
+  std::vector<int> calcDescrepancyAndParseDynamicPointIdxForEachScan(std::pair<int, int> _rimg_shape);
 
-    std::vector<int> getStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes, int _num_all_points);
-    std::vector<int> getGlobalMapStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes);
+  std::vector<int> getStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes, int _num_all_points);
+  std::vector<int> getGlobalMapStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes);
 
-    void parsePointcloudSubsetUsingPtIdx( const pcl::PointCloud<PointType>::Ptr& _ptcloud_orig,
-            std::vector<int>& _point_indexes, pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save );
-    void parseMapPointcloudSubsetUsingPtIdx( std::vector<int>& _point_indexes, pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save );
-    void parseStaticMapPointcloudUsingPtIdx( std::vector<int>& _point_indexes );
-    void parseDynamicMapPointcloudUsingPtIdx( std::vector<int>& _point_indexes );
+  void parsePointcloudSubsetUsingPtIdx(const pcl::PointCloud<PointType>::Ptr& _ptcloud_orig,
+                                       std::vector<int>& _point_indexes,
+                                       pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save);
+  void parseMapPointcloudSubsetUsingPtIdx(std::vector<int>& _point_indexes,
+                                          pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save);
+  void parseStaticMapPointcloudUsingPtIdx(std::vector<int>& _point_indexes);
+  void parseDynamicMapPointcloudUsingPtIdx(std::vector<int>& _point_indexes);
 
-    void saveCurrentStaticAndDynamicPointCloudGlobal( void );
-    void saveCurrentStaticAndDynamicPointCloudLocal( int _base_pose_idx  = 0);
+  void saveCurrentStaticAndDynamicPointCloudGlobal(void);
+  void saveCurrentStaticAndDynamicPointCloudLocal(int _base_pose_idx = 0);
 
-    // void local2global(const pcl::PointCloud<PointType>::Ptr& _ptcloud_global, pcl::PointCloud<PointType>::Ptr& _ptcloud_local_to_save );
-    pcl::PointCloud<PointType>::Ptr local2global(const pcl::PointCloud<PointType>::Ptr& _scan_local, int _scan_idx);
-    pcl::PointCloud<PointType>::Ptr global2local(const pcl::PointCloud<PointType>::Ptr& _scan_global, int _scan_idx);
+  // void local2global(const pcl::PointCloud<PointType>::Ptr& _ptcloud_global, pcl::PointCloud<PointType>::Ptr&
+  // _ptcloud_local_to_save );
+  pcl::PointCloud<PointType>::Ptr local2global(const pcl::PointCloud<PointType>::Ptr& _scan_local, int _scan_idx);
+  pcl::PointCloud<PointType>::Ptr global2local(const pcl::PointCloud<PointType>::Ptr& _scan_global, int _scan_idx);
 
-    // scan-side removal
-    std::pair<pcl::PointCloud<PointType>::Ptr, pcl::PointCloud<PointType>::Ptr> removeDynamicPointsOfScanByKnn ( int _scan_idx );
-    void removeDynamicPointsAndSaveStaticScanForEachScan( void );
+  // scan-side removal
+  std::pair<pcl::PointCloud<PointType>::Ptr, pcl::PointCloud<PointType>::Ptr>
+  removeDynamicPointsOfScanByKnn(int _scan_idx);
+  void removeDynamicPointsAndSaveStaticScanForEachScan(void);
 
-    void scansideRemovalForEachScan(void);
-    void saveCleanedScans(void);
-    void saveMapPointcloudByMergingCleanedScans(void);
-    void scansideRemovalForEachScanAndSaveThem(void);
+  void scansideRemovalForEachScan(void);
+  void saveCleanedScans(void);
+  void saveMapPointcloudByMergingCleanedScans(void);
+  void scansideRemovalForEachScanAndSaveThem(void);
 
-    void saveStaticScan( int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud );
-    void saveDynamicScan( int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud );
+  void saveStaticScan(int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud);
+  void saveDynamicScan(int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud);
 
-}; // Removerter
+};  // Removerter

--- a/include/removert/Removerter.h
+++ b/include/removert/Removerter.h
@@ -39,6 +39,9 @@ private:
   pcl::PointCloud<PointType>::Ptr map_global_curr_static_;   // the S_i
   pcl::PointCloud<PointType>::Ptr map_global_curr_dynamic_;  // the D_i
 
+  pcl::PointCloud<PointType>::Ptr output_map_global_static_;
+  pcl::PointCloud<PointType>::Ptr output_map_global_dynamic_;
+
   pcl::PointCloud<PointType>::Ptr map_global_accumulated_static_;   // TODO, the S_i after reverted
   pcl::PointCloud<PointType>::Ptr map_global_accumulated_dynamic_;  // TODO, the D_i after reverted
 
@@ -114,8 +117,8 @@ public:
   void parseStaticMapPointcloudUsingPtIdx(std::vector<int>& _point_indexes);
   void parseDynamicMapPointcloudUsingPtIdx(std::vector<int>& _point_indexes);
 
-  void saveCurrentStaticAndDynamicPointCloudGlobal(void);
-  void saveCurrentStaticAndDynamicPointCloudLocal(int _base_pose_idx = 0);
+  void saveCurrentStaticAndDynamicPointCloudGlobal(bool _reverted = false);
+  void saveCurrentStaticAndDynamicPointCloudLocal(int _base_pose_idx = 0, bool _reverted = false);
 
   // void local2global(const pcl::PointCloud<PointType>::Ptr& _ptcloud_global, pcl::PointCloud<PointType>::Ptr&
   // _ptcloud_local_to_save );

--- a/include/removert/Removerter.h
+++ b/include/removert/Removerter.h
@@ -11,12 +11,6 @@ private:
                                        // scan range (e.g., 200 meters)
   const float kValidDiffUpperBound = 200.0;  // must smaller than kFlagNoPOINT
 
-  // Static sensitivity
-  int kNumKnnPointsToCompare;  // static sensitivity (increase this value, less static structure will be removed at the
-                               // scan-side removal stage)
-  float kScanKnnAndMapKnnAvgDiffThreshold;  // static sensitivity (decrease this value, less static structure will be
-                                            // removed at the scan-side removal stage)
-
   std::vector<std::string> sequence_valid_scan_names_;
   std::vector<std::string> sequence_valid_scan_paths_;
   std::vector<pcl::PointCloud<PointType>::Ptr> scans_;

--- a/include/removert/RosParamServer.h
+++ b/include/removert/RosParamServer.h
@@ -5,106 +5,105 @@
 class RosNodeHandle
 {
 public:
-    ros::NodeHandle nh_super;
-}; // class: RosNodeHandle
+  ros::NodeHandle nh_super;
+};  // class: RosNodeHandle
 
-
-class RosParamServer: public RosNodeHandle
+class RosParamServer : public RosNodeHandle
 {
 public:
-    // 
-    ros::NodeHandle & nh;
+  //
+  ros::NodeHandle& nh;
 
-    //
-    std::string pointcloud_topic;
+  //
+  std::string pointcloud_topic;
 
-    // removert params 
-    float kVFOV;
-    float kHFOV;
-    std::pair<float, float> kFOV;
+  // removert params
+  float kVFOV;
+  float kHFOV;
+  std::pair<float, float> kFOV;
 
-    // sequence info 
-    std::vector<double> kVecExtrinsicLiDARtoPoseBase; 
-    Eigen::Matrix4d kSE3MatExtrinsicLiDARtoPoseBase;
-        // Base is where of the pose writtened (e.g., for KITTI, poses is usually in camera)
-        // if the pose file is obtained via lidar odometry itself, then kMatExtrinsicLiDARtoBase is eye(4)
-    Eigen::Matrix4d kSE3MatExtrinsicPoseBasetoLiDAR;
+  // sequence info
+  std::vector<double> kVecExtrinsicLiDARtoPoseBase;
+  Eigen::Matrix4d kSE3MatExtrinsicLiDARtoPoseBase;
+  // Base is where of the pose writtened (e.g., for KITTI, poses is usually in camera)
+  // if the pose file is obtained via lidar odometry itself, then kMatExtrinsicLiDARtoBase is eye(4)
+  Eigen::Matrix4d kSE3MatExtrinsicPoseBasetoLiDAR;
 
-    // sequence bin files
-    bool isScanFileKITTIFormat_;
+  // sequence bin files
+  bool isScanFileKITTIFormat_;
 
-    std::string sequence_scan_dir_;
-    std::vector<std::string> sequence_scan_names_;
-    std::vector<std::string> sequence_scan_paths_;
-    int num_total_scans_of_sequence_;
-    float kDownsampleVoxelSize;
+  std::string sequence_scan_dir_;
+  std::vector<std::string> sequence_scan_names_;
+  std::vector<std::string> sequence_scan_paths_;
+  int num_total_scans_of_sequence_;
+  float kDownsampleVoxelSize;
 
-    // sequence pose file
-    std::string sequence_pose_path_;
-    std::vector<Eigen::Matrix4d> sequence_scan_poses_;
-    std::vector<Eigen::Matrix4d> sequence_scan_inverse_poses_; // used for global to local
+  // sequence pose file
+  std::string sequence_pose_path_;
+  std::vector<Eigen::Matrix4d> sequence_scan_poses_;
+  std::vector<Eigen::Matrix4d> sequence_scan_inverse_poses_;  // used for global to local
 
-    // target region to removerting 
-    int start_idx_;
-    int end_idx_;
+  // target region to removerting
+  int start_idx_;
+  int end_idx_;
 
-    bool use_keyframe_gap_; 
-    bool use_keyframe_meter_; 
-    int keyframe_gap_;
-    float keyframe_gap_meter_;
+  bool use_keyframe_gap_;
+  bool use_keyframe_meter_;
+  int keyframe_gap_;
+  float keyframe_gap_meter_;
 
-    // 
-    std::vector<float> remove_resolution_list_;
-    std::vector<float> revert_resolution_list_;
+  //
+  std::vector<float> remove_resolution_list_;
+  std::vector<float> revert_resolution_list_;
 
-    // 
-    int kNumOmpCores;
+  //
+  int kNumOmpCores;
 
-    //
-    pcl::PointCloud<PointType>::Ptr single_scan;
-    pcl::PointCloud<PointType>::Ptr projected_scan;
+  //
+  pcl::PointCloud<PointType>::Ptr single_scan;
+  pcl::PointCloud<PointType>::Ptr projected_scan;
 
-    // ros pub
-    ros::Publisher scan_publisher_;
-    ros::Publisher global_scan_publisher_;
+  // ros pub
+  ros::Publisher scan_publisher_;
+  ros::Publisher global_scan_publisher_;
 
-    ros::Publisher original_map_local_publisher_;
+  ros::Publisher original_map_local_publisher_;
 
-    ros::Publisher curr_map_local_publisher_;
-    ros::Publisher static_map_local_publisher_;
-    ros::Publisher dynamic_map_local_publisher_;
+  ros::Publisher curr_map_local_publisher_;
+  ros::Publisher static_map_local_publisher_;
+  ros::Publisher dynamic_map_local_publisher_;
 
-    ros::Publisher static_curr_scan_publisher_;
-    ros::Publisher dynamic_curr_scan_publisher_;
+  ros::Publisher static_curr_scan_publisher_;
+  ros::Publisher dynamic_curr_scan_publisher_;
 
-    float rimg_color_min_;
-    float rimg_color_max_;
-    std::pair<float, float> kRangeColorAxis; // meter
-    std::pair<float, float> kRangeColorAxisForDiff; // meter 
+  float rimg_color_min_;
+  float rimg_color_max_;
+  std::pair<float, float> kRangeColorAxis;         // meter
+  std::pair<float, float> kRangeColorAxisForDiff;  // meter
 
-    image_transport::ImageTransport ROSimg_transporter_;
+  image_transport::ImageTransport ROSimg_transporter_;
 
-    sensor_msgs::ImagePtr scan_rimg_msg_;
-    image_transport::Publisher scan_rimg_msg_publisher_;
+  sensor_msgs::ImagePtr scan_rimg_msg_;
+  image_transport::Publisher scan_rimg_msg_publisher_;
 
-    sensor_msgs::ImagePtr map_rimg_msg_;
-    image_transport::Publisher map_rimg_msg_publisher_;
+  sensor_msgs::ImagePtr map_rimg_msg_;
+  image_transport::Publisher map_rimg_msg_publisher_;
 
-    sensor_msgs::ImagePtr diff_rimg_msg_;
-    image_transport::Publisher diff_rimg_msg_publisher_;
+  sensor_msgs::ImagePtr diff_rimg_msg_;
+  image_transport::Publisher diff_rimg_msg_publisher_;
 
-    sensor_msgs::ImagePtr map_rimg_ptidx_msg_;
-    image_transport::Publisher map_rimg_ptidx_msg_publisher_;
+  sensor_msgs::ImagePtr map_rimg_ptidx_msg_;
+  image_transport::Publisher map_rimg_ptidx_msg_publisher_;
 
-    //
-    bool kFlagSaveMapPointcloud;
-    bool kFlagSaveCleanScans;
-    std::string save_pcd_directory_;
+  //
+  bool kFlagSaveMapPointcloud;
+  bool kFlagSaveCleanScans;
+  std::string save_pcd_directory_;
 
-    // colorize
-    bool use_rgb;
+  // colorize
+  bool use_rgb;
 
 public:
-    RosParamServer();
+  RosParamServer();
 
-}; // class: RosParamServer
+};  // class: RosParamServer

--- a/include/removert/RosParamServer.h
+++ b/include/removert/RosParamServer.h
@@ -60,6 +60,11 @@ public:
   //
   int kNumOmpCores;
 
+  // scan-side removals
+  bool scan_side_removals_;
+  int kNumKnnPointsToCompare;
+  float kScanKnnAndMapKnnAvgDiffThreshold;
+
   //
   pcl::PointCloud<PointType>::Ptr single_scan;
   pcl::PointCloud<PointType>::Ptr projected_scan;

--- a/include/removert/RosParamServer.h
+++ b/include/removert/RosParamServer.h
@@ -46,6 +46,7 @@ public:
   // target region to removerting
   int start_idx_;
   int end_idx_;
+  bool clean_for_all_scan_;
 
   bool use_keyframe_gap_;
   bool use_keyframe_meter_;

--- a/include/removert/utility.h
+++ b/include/removert/utility.h
@@ -31,7 +31,7 @@
 #include <pcl/filters/filter.h>
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/octree/octree_pointcloud_voxelcentroid.h>
-#include <pcl/filters/crop_box.h> 
+#include <pcl/filters/crop_box.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <Eigen/Dense>
@@ -44,7 +44,7 @@
 #include <tf/transform_listener.h>
 #include <tf/transform_datatypes.h>
 #include <tf/transform_broadcaster.h>
- 
+
 #include <opencv2/highgui/highgui.hpp>
 #include <image_transport/image_transport.h>
 
@@ -68,13 +68,13 @@
 #include <thread>
 #include <mutex>
 
-#include <filesystem> // requires gcc version >= 8
+#include <filesystem>  // requires gcc version >= 8
 
 namespace fs = std::filesystem;
-using std::ios;
-using std::cout;
 using std::cerr;
+using std::cout;
 using std::endl;
+using std::ios;
 
 // struct PointXYZIS
 // {
@@ -84,29 +84,27 @@ using std::endl;
 //     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 // } EIGEN_ALIGN16;
 
-// POINT_CLOUD_REGISTER_POINT_STRUCT (PointXYZIS,  
+// POINT_CLOUD_REGISTER_POINT_STRUCT (PointXYZIS,
 //     (float, x, x) (float, y, y) (float, z, z) (float, intensity, intensity) (float, score, score)
 // )
 
 struct EIGEN_ALIGN16 PointXYZRGBI
 {
-    PCL_ADD_POINT4D
-    PCL_ADD_RGB;
-    PCL_ADD_INTENSITY;
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_ADD_POINT4D
+  PCL_ADD_RGB;
+  PCL_ADD_INTENSITY;
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
-POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZRGBI, 
-                                  (float, x, x)(float, y, y)(float, z, z)
-                                  (float, rgb, rgb)
-                                  (float, intensity, intensity))
+POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZRGBI,
+                                  (float, x, x)(float, y, y)(float, z, z)(float, rgb, rgb)(float, intensity, intensity))
 
 using PointType = PointXYZRGBI;
 
 struct SphericalPoint
 {
-    float az; // azimuth 
-    float el; // elevation
-    float r; // radius
+  float az;  // azimuth
+  float el;  // elevation
+  float r;   // radius
 };
 
 inline float rad2deg(float radians);
@@ -116,12 +114,12 @@ void readBin(std::string _bin_path, pcl::PointCloud<PointType>::Ptr _pcd_ptr);
 
 std::vector<double> splitPoseLine(std::string _str_line, char _delimiter);
 
-SphericalPoint cart2sph(const PointType & _cp);
+SphericalPoint cart2sph(const PointType& _cp);
 
 std::pair<int, int> resetRimgSize(const std::pair<float, float> _fov, const float _resize_ratio);
 
-template<typename T>
-cv::Mat convertColorMappedImg (const cv::Mat &_src, std::pair<T, T> _caxis)
+template <typename T>
+cv::Mat convertColorMappedImg(const cv::Mat& _src, std::pair<T, T> _caxis)
 {
   T min_color_val = _caxis.first;
   T max_color_val = _caxis.second;
@@ -129,35 +127,38 @@ cv::Mat convertColorMappedImg (const cv::Mat &_src, std::pair<T, T> _caxis)
   cv::Mat image_dst;
   image_dst = 255 * (_src - min_color_val) / (max_color_val - min_color_val);
   image_dst.convertTo(image_dst, CV_8UC1);
-  
+
   cv::applyColorMap(image_dst, image_dst, cv::COLORMAP_JET);
 
   return image_dst;
 }
 
-std::set<int> convertIntVecToSet(const std::vector<int> & v);
+std::set<int> convertIntVecToSet(const std::vector<int>& v);
 
 template <typename T>
-std::vector<T> linspace(T a, T b, size_t N) {
-    T h = (b - a) / static_cast<T>(N-1);
-    std::vector<T> xs(N);
-    typename std::vector<T>::iterator x;
-    T val;
-    for (x = xs.begin(), val = a; x != xs.end(); ++x, val += h)
-        *x = val;
-    return xs;
+std::vector<T> linspace(T a, T b, size_t N)
+{
+  T h = (b - a) / static_cast<T>(N - 1);
+  std::vector<T> xs(N);
+  typename std::vector<T>::iterator x;
+  T val;
+  for (x = xs.begin(), val = a; x != xs.end(); ++x, val += h)
+    *x = val;
+  return xs;
 }
 
-sensor_msgs::ImagePtr cvmat2msg(const cv::Mat &_img);
+sensor_msgs::ImagePtr cvmat2msg(const cv::Mat& _img);
 
-void pubRangeImg(cv::Mat& _rimg, sensor_msgs::ImagePtr& _msg, image_transport::Publisher& _publiser, std::pair<float, float> _caxis);
+void pubRangeImg(cv::Mat& _rimg, sensor_msgs::ImagePtr& _msg, image_transport::Publisher& _publiser,
+                 std::pair<float, float> _caxis);
 void publishPointcloud2FromPCLptr(const ros::Publisher& _scan_publisher, const pcl::PointCloud<PointType>::Ptr _scan);
-sensor_msgs::PointCloud2 publishCloud(ros::Publisher *thisPub, pcl::PointCloud<PointType>::Ptr thisCloud, ros::Time thisStamp, std::string thisFrame);
+sensor_msgs::PointCloud2 publishCloud(ros::Publisher* thisPub, pcl::PointCloud<PointType>::Ptr thisCloud,
+                                      ros::Time thisStamp, std::string thisFrame);
 
-template<typename T>
+template <typename T>
 double ROS_TIME(T msg)
 {
-    return msg->header.stamp.toSec();
+  return msg->header.stamp.toSec();
 }
 
 float pointDistance(PointType p);

--- a/src/Removerter.cpp
+++ b/src/Removerter.cpp
@@ -30,10 +30,6 @@ Removerter::Removerter()
   pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
   // pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);
 
-  nh.param<int>("removert/num_nn_points_within", kNumKnnPointsToCompare, 3);  // using higher, more strict static
-  nh.param<float>("removert/dist_nn_points_within", kScanKnnAndMapKnnAvgDiffThreshold,
-                  0.1);  // using smaller, more strict static
-
   if (save_pcd_directory_.substr(save_pcd_directory_.size() - 1, 1) != std::string("/"))
     save_pcd_directory_ = save_pcd_directory_ + "/";
   fsmkdir(save_pcd_directory_);
@@ -976,5 +972,8 @@ void Removerter::run(void)
   }
 
   // scan-side removals
-  scansideRemovalForEachScanAndSaveThem();
+  if (scan_side_removals_)
+  {
+    scansideRemovalForEachScanAndSaveThem();
+  }
 }

--- a/src/Removerter.cpp
+++ b/src/Removerter.cpp
@@ -1,927 +1,980 @@
 #include "removert/Removerter.h"
 
-inline float rad2deg(float radians) 
-{ 
-    return radians * 180.0 / M_PI; 
+inline float rad2deg(float radians)
+{
+  return radians * 180.0 / M_PI;
 }
 
-inline float deg2rad(float degrees) 
-{ 
-    return degrees * M_PI / 180.0; 
+inline float deg2rad(float degrees)
+{
+  return degrees * M_PI / 180.0;
 }
 
 void Removerter::cloudHandler(const sensor_msgs::PointCloud2ConstPtr& laserCloudMsg)
 {
-    cout << "TODO" << endl;
+  cout << "TODO" << endl;
 }
 
 void fsmkdir(std::string _path)
 {
-    if (!fs::is_directory(_path) || !fs::exists(_path)) 
-        fs::create_directories(_path); // create src folder
-} //fsmkdir
+  if (!fs::is_directory(_path) || !fs::exists(_path))
+    fs::create_directories(_path);  // create src folder
+}  // fsmkdir
 
 Removerter::Removerter()
 {
-    subLaserCloud = nh.subscribe<sensor_msgs::PointCloud2>("/os1_points", 5, &Removerter::cloudHandler, this, ros::TransportHints().tcpNoDelay());
+  subLaserCloud = nh.subscribe<sensor_msgs::PointCloud2>("/os1_points", 5, &Removerter::cloudHandler, this,
+                                                         ros::TransportHints().tcpNoDelay());
 
-    // voxelgrid generates warnings frequently, so verbose off + ps. recommend to use octree (see makeGlobalMap)
-    pcl::console::setVerbosityLevel(pcl::console::L_ERROR); 
-    // pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);
+  // voxelgrid generates warnings frequently, so verbose off + ps. recommend to use octree (see makeGlobalMap)
+  pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
+  // pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);
 
-    nh.param<int>("removert/num_nn_points_within", kNumKnnPointsToCompare, 3); // using higher, more strict static 
-    nh.param<float>("removert/dist_nn_points_within", kScanKnnAndMapKnnAvgDiffThreshold, 0.1); // using smaller, more strict static 
+  nh.param<int>("removert/num_nn_points_within", kNumKnnPointsToCompare, 3);  // using higher, more strict static
+  nh.param<float>("removert/dist_nn_points_within", kScanKnnAndMapKnnAvgDiffThreshold,
+                  0.1);  // using smaller, more strict static
 
-    if( save_pcd_directory_.substr(save_pcd_directory_.size()-1, 1) != std::string("/") )
-        save_pcd_directory_ = save_pcd_directory_ + "/";
-    fsmkdir(save_pcd_directory_);
-    scan_static_save_dir_ = save_pcd_directory_ + "scan_static"; fsmkdir(scan_static_save_dir_);
-    scan_dynamic_save_dir_ = save_pcd_directory_ + "scan_dynamic"; fsmkdir(scan_dynamic_save_dir_);
-    map_static_save_dir_ = save_pcd_directory_ + "map_static"; fsmkdir(map_static_save_dir_);
-    map_dynamic_save_dir_ = save_pcd_directory_ + "map_dynamic"; fsmkdir(map_dynamic_save_dir_);
+  if (save_pcd_directory_.substr(save_pcd_directory_.size() - 1, 1) != std::string("/"))
+    save_pcd_directory_ = save_pcd_directory_ + "/";
+  fsmkdir(save_pcd_directory_);
+  scan_static_save_dir_ = save_pcd_directory_ + "scan_static";
+  fsmkdir(scan_static_save_dir_);
+  scan_dynamic_save_dir_ = save_pcd_directory_ + "scan_dynamic";
+  fsmkdir(scan_dynamic_save_dir_);
+  map_static_save_dir_ = save_pcd_directory_ + "map_static";
+  fsmkdir(map_static_save_dir_);
+  map_dynamic_save_dir_ = save_pcd_directory_ + "map_dynamic";
+  fsmkdir(map_dynamic_save_dir_);
 
-    allocateMemory();
+  allocateMemory();
 
-    // ros pub for visual debug
-    scan_publisher_ = nh.advertise<sensor_msgs::PointCloud2> ("removert/scan_single_local", 1);
-    global_scan_publisher_ = nh.advertise<sensor_msgs::PointCloud2> ("removert/scan_single_global", 1);
+  // ros pub for visual debug
+  scan_publisher_ = nh.advertise<sensor_msgs::PointCloud2>("removert/scan_single_local", 1);
+  global_scan_publisher_ = nh.advertise<sensor_msgs::PointCloud2>("removert/scan_single_global", 1);
 
-    original_map_local_publisher_ = nh.advertise<sensor_msgs::PointCloud2> ("removert/original_map", 10);
+  original_map_local_publisher_ = nh.advertise<sensor_msgs::PointCloud2>("removert/original_map", 10);
 
-    curr_map_local_publisher_ =  nh.advertise<sensor_msgs::PointCloud2> ("removert/curr_map", 1);
-    static_map_local_publisher_ = nh.advertise<sensor_msgs::PointCloud2> ("removert/static_map", 1);
-    dynamic_map_local_publisher_ = nh.advertise<sensor_msgs::PointCloud2> ("removert/dynamic_map", 1);
+  curr_map_local_publisher_ = nh.advertise<sensor_msgs::PointCloud2>("removert/curr_map", 1);
+  static_map_local_publisher_ = nh.advertise<sensor_msgs::PointCloud2>("removert/static_map", 1);
+  dynamic_map_local_publisher_ = nh.advertise<sensor_msgs::PointCloud2>("removert/dynamic_map", 1);
 
-    static_curr_scan_publisher_ = nh.advertise<sensor_msgs::PointCloud2> ("removert/scan_single_local_static", 1);
-    dynamic_curr_scan_publisher_ = nh.advertise<sensor_msgs::PointCloud2> ("removert/scan_single_local_dynamic", 1);
+  static_curr_scan_publisher_ = nh.advertise<sensor_msgs::PointCloud2>("removert/scan_single_local_static", 1);
+  dynamic_curr_scan_publisher_ = nh.advertise<sensor_msgs::PointCloud2>("removert/scan_single_local_dynamic", 1);
 
-} // ctor
-
+}  // ctor
 
 void Removerter::allocateMemory()
 {
-    map_global_orig_.reset(new pcl::PointCloud<PointType>());
+  map_global_orig_.reset(new pcl::PointCloud<PointType>());
 
-    map_global_curr_.reset(new pcl::PointCloud<PointType>());
-    map_local_curr_.reset(new pcl::PointCloud<PointType>());
+  map_global_curr_.reset(new pcl::PointCloud<PointType>());
+  map_local_curr_.reset(new pcl::PointCloud<PointType>());
 
-    map_global_curr_static_.reset(new pcl::PointCloud<PointType>());
-    map_global_curr_dynamic_.reset(new pcl::PointCloud<PointType>());
+  map_global_curr_static_.reset(new pcl::PointCloud<PointType>());
+  map_global_curr_dynamic_.reset(new pcl::PointCloud<PointType>());
 
-    map_subset_global_curr_.reset(new pcl::PointCloud<PointType>());
+  map_subset_global_curr_.reset(new pcl::PointCloud<PointType>());
 
-    kdtree_map_global_curr_.reset(new pcl::KdTreeFLANN<PointType>());
-    kdtree_scan_global_curr_.reset(new pcl::KdTreeFLANN<PointType>());
+  kdtree_map_global_curr_.reset(new pcl::KdTreeFLANN<PointType>());
+  kdtree_scan_global_curr_.reset(new pcl::KdTreeFLANN<PointType>());
+
+  //
+  map_global_orig_->clear();
+  map_global_curr_->clear();
+  map_local_curr_->clear();
+  map_global_curr_static_->clear();
+  map_global_curr_dynamic_->clear();
+  map_subset_global_curr_->clear();
+
+}  // allocateMemory
+
+Removerter::~Removerter()
+{
+}
+
+void Removerter::parseValidScanInfo(void)
+{
+  int num_valid_parsed{ 0 };
+  float movement_counter{ 0.0 };
+
+  for (int curr_idx = 0; curr_idx < int(sequence_scan_paths_.size()); curr_idx++)
+  {
+    // check the scan idx within the target idx range
+    if (curr_idx > end_idx_ || curr_idx < start_idx_)
+    {
+      curr_idx++;
+      continue;
+    }
+
+    // check enough movement occured (e.g., parse every 2m)
+    if (use_keyframe_gap_)
+    {
+      if (remainder(num_valid_parsed, keyframe_gap_) != 0)
+      {
+        num_valid_parsed++;
+        continue;
+      }
+    }
+    if (use_keyframe_meter_)
+    {
+      if (0 /*TODO*/)
+      {
+        // TODO using movement_counter
+      }
+    }
+
+    // save the info (reading scan bin is in makeGlobalMap)
+    sequence_valid_scan_paths_.emplace_back(sequence_scan_paths_.at(curr_idx));
+    sequence_valid_scan_names_.emplace_back(sequence_scan_names_.at(curr_idx));
+
+    scan_poses_.emplace_back(sequence_scan_poses_.at(curr_idx));                  // used for local2global
+    scan_inverse_poses_.emplace_back(sequence_scan_inverse_poses_.at(curr_idx));  // used for global2local
 
     //
-    map_global_orig_->clear();
-    map_global_curr_->clear();
-    map_local_curr_->clear();
-    map_global_curr_static_->clear();
-    map_global_curr_dynamic_->clear();
-    map_subset_global_curr_->clear();
+    num_valid_parsed++;
+  }
 
-} // allocateMemory
+  if (use_keyframe_gap_)
+  {
+    ROS_INFO_STREAM("\033[1;32m Total " << sequence_valid_scan_paths_.size() << " nodes are used from the index range ["
+                                        << start_idx_ << ", " << end_idx_ << "]"
+                                        << " (every " << keyframe_gap_ << " frames parsed)\033[0m");
+  }
+}  // parseValidScanInfo
 
-
-Removerter::~Removerter(){}
-
-
-void Removerter::parseValidScanInfo( void )
+void Removerter::readValidScans(void)
+// for target range of scan idx
 {
-    int num_valid_parsed {0};
-    float movement_counter {0.0}; 
+  const int cout_interval{ 10 };
+  int cout_counter{ 0 };
 
-    for(int curr_idx=0; curr_idx < int(sequence_scan_paths_.size()); curr_idx++) 
+  for (auto& _scan_path : sequence_valid_scan_paths_)
+  {
+    // read bin files and save
+    pcl::PointCloud<PointType>::Ptr points(
+        new pcl::PointCloud<PointType>);  // pcl::PointCloud Ptr is a shared ptr so this points will be automatically
+                                          // destroyed after this function block (because no others ref it).
+    if (isScanFileKITTIFormat_)
     {
-        // check the scan idx within the target idx range 
-        if(curr_idx > end_idx_ || curr_idx < start_idx_) {
-            curr_idx++;
-            continue;
-        }
-
-        // check enough movement occured (e.g., parse every 2m)
-        if(use_keyframe_gap_) {
-            if( remainder(num_valid_parsed, keyframe_gap_) != 0 ) {
-                num_valid_parsed++;
-                continue;
-            }
-        }
-        if(use_keyframe_meter_) {
-            if( 0 /*TODO*/ ) {
-                // TODO using movement_counter
-            }
-        }
-
-        // save the info (reading scan bin is in makeGlobalMap) 
-        sequence_valid_scan_paths_.emplace_back(sequence_scan_paths_.at(curr_idx));
-        sequence_valid_scan_names_.emplace_back(sequence_scan_names_.at(curr_idx));
-
-        scan_poses_.emplace_back(sequence_scan_poses_.at(curr_idx)); // used for local2global
-        scan_inverse_poses_.emplace_back(sequence_scan_inverse_poses_.at(curr_idx)); // used for global2local
-
-        // 
-        num_valid_parsed++;
+      readBin(_scan_path, points);  // For KITTI (.bin)
     }
-
-    if(use_keyframe_gap_) {
-        ROS_INFO_STREAM("\033[1;32m Total " << sequence_valid_scan_paths_.size()
-            << " nodes are used from the index range [" << start_idx_ << ", " << end_idx_ << "]" 
-            << " (every " << keyframe_gap_ << " frames parsed)\033[0m");
-    }
-} // parseValidScanInfo
-
-
-void Removerter::readValidScans( void )
-// for target range of scan idx 
-{
-    const int cout_interval {10};
-    int cout_counter {0};
-
-    for(auto& _scan_path : sequence_valid_scan_paths_) 
+    else
     {
-        // read bin files and save  
-        pcl::PointCloud<PointType>::Ptr points (new pcl::PointCloud<PointType>); // pcl::PointCloud Ptr is a shared ptr so this points will be automatically destroyed after this function block (because no others ref it).
-        if( isScanFileKITTIFormat_ ) {
-            readBin(_scan_path, points); // For KITTI (.bin)
-        } else {
-            pcl::io::loadPCDFile<PointType> (_scan_path, *points); // saved from SC-LIO-SAM's pcd binary (.pcd)
-        }
-
-        // pcdown
-        pcl::VoxelGrid<PointType> downsize_filter;
-        downsize_filter.setLeafSize(kDownsampleVoxelSize, kDownsampleVoxelSize, kDownsampleVoxelSize);
-        downsize_filter.setInputCloud(points);
-
-        pcl::PointCloud<PointType>::Ptr downsampled_points (new pcl::PointCloud<PointType>);
-        downsize_filter.filter(*downsampled_points);
-
-        // save downsampled pointcloud
-        scans_.emplace_back(downsampled_points);
-
-        // cout for debug  
-        cout_counter++;
-        if (remainder(cout_counter, cout_interval) == 0) {
-            cout << _scan_path << endl;
-            cout << "Read a pointcloud with " << points->points.size() << " points." << endl;
-            cout << "downsample the pointcloud: " << downsampled_points->points.size() << " points." << endl;
-            cout << " ... (display every " << cout_interval << " readings) ..." << endl;
-        }
-    }
-    cout << endl;
-} // readValidScans
-
-
-std::pair<cv::Mat, cv::Mat> Removerter::map2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan, 
-                      const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25, lower 25), hfov = 360] */
-                      const std::pair<int, int> _rimg_size)
-{
-    const float kVFOV = _fov.first;
-    const float kHFOV = _fov.second;
-    
-    const int kNumRimgRow = _rimg_size.first;
-    const int kNumRimgCol = _rimg_size.second;
-
-    // @ range image initizliation 
-    cv::Mat rimg = cv::Mat(kNumRimgRow, kNumRimgCol, CV_32FC1, cv::Scalar::all(kFlagNoPOINT)); // float matrix, save range value 
-    cv::Mat rimg_ptidx = cv::Mat(kNumRimgRow, kNumRimgCol, CV_32SC1, cv::Scalar::all(0)); // int matrix, save point (of global map) index
-
-    // @ points to range img 
-    int num_points = _scan->points.size();
-    #pragma omp parallel for num_threads(kNumOmpCores)
-    for (int pt_idx = 0; pt_idx < num_points; ++pt_idx)
-    {   
-        PointType this_point = _scan->points[pt_idx];
-        SphericalPoint sph_point = cart2sph(this_point);
-
-        // @ note about vfov: e.g., (+ V_FOV/2) to adjust [-15, 15] to [0, 30]
-        // @ min and max is just for the easier (naive) boundary checks. 
-        int lower_bound_row_idx {0}; 
-        int lower_bound_col_idx {0};
-        int upper_bound_row_idx {kNumRimgRow - 1}; 
-        int upper_bound_col_idx {kNumRimgCol - 1};
-        int pixel_idx_row = int(std::min(std::max(std::round(kNumRimgRow * (1 - (rad2deg(sph_point.el) + (kVFOV/float(2.0))) / (kVFOV - float(0.0)))), float(lower_bound_row_idx)), float(upper_bound_row_idx)));
-        int pixel_idx_col = int(std::min(std::max(std::round(kNumRimgCol * ((rad2deg(sph_point.az) + (kHFOV/float(2.0))) / (kHFOV - float(0.0)))), float(lower_bound_col_idx)), float(upper_bound_col_idx)));
-
-        float curr_range = sph_point.r;
-
-        // @ Theoretically, this if-block would have race condition (i.e., this is a critical section), 
-        // @ But, the resulting range image is acceptable (watching via Rviz), 
-        // @      so I just naively applied omp pragma for this whole for-block (2020.10.28)
-        // @ Reason: because this for loop is splited by the omp, points in a single splited for range do not race among them, 
-        // @         also, a point A and B lied in different for-segments do not tend to correspond to the same pixel, 
-        // #               so we can assume practically there are few race conditions.     
-        // @ P.S. some explicit mutexing directive makes the code even slower ref: https://stackoverflow.com/questions/2396430/how-to-use-lock-in-openmp
-        if ( curr_range < rimg.at<float>(pixel_idx_row, pixel_idx_col) ) {
-            rimg.at<float>(pixel_idx_row, pixel_idx_col) = curr_range;
-            rimg_ptidx.at<int>(pixel_idx_row, pixel_idx_col) = pt_idx;
-        }
+      pcl::io::loadPCDFile<PointType>(_scan_path, *points);  // saved from SC-LIO-SAM's pcd binary (.pcd)
     }
 
-    return std::pair<cv::Mat, cv::Mat>(rimg, rimg_ptidx);
-} // map2RangeImg
+    // pcdown
+    pcl::VoxelGrid<PointType> downsize_filter;
+    downsize_filter.setLeafSize(kDownsampleVoxelSize, kDownsampleVoxelSize, kDownsampleVoxelSize);
+    downsize_filter.setInputCloud(points);
 
+    pcl::PointCloud<PointType>::Ptr downsampled_points(new pcl::PointCloud<PointType>);
+    downsize_filter.filter(*downsampled_points);
 
-cv::Mat Removerter::scan2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan, 
-                      const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25, lower 25), hfov = 360] */
-                      const std::pair<int, int> _rimg_size)
-{
-    const float kVFOV = _fov.first;
-    const float kHFOV = _fov.second;
-    
-    const int kNumRimgRow = _rimg_size.first;
-    const int kNumRimgCol = _rimg_size.second;
-    // cout << "rimg size is: [" << _rimg_size.first << ", " << _rimg_size.second << "]." << endl;
+    // save downsampled pointcloud
+    scans_.emplace_back(downsampled_points);
 
-    // @ range image initizliation 
-    cv::Mat rimg = cv::Mat(kNumRimgRow, kNumRimgCol, CV_32FC1, cv::Scalar::all(kFlagNoPOINT)); // float matrix
-
-    // @ points to range img 
-    int num_points = _scan->points.size();
-    #pragma omp parallel for num_threads(kNumOmpCores)
-    for (int pt_idx = 0; pt_idx < num_points; ++pt_idx)
-    {   
-        PointType this_point = _scan->points[pt_idx];
-        SphericalPoint sph_point = cart2sph(this_point);
-
-        // @ note about vfov: e.g., (+ V_FOV/2) to adjust [-15, 15] to [0, 30]
-        // @ min and max is just for the easier (naive) boundary checks. 
-        int lower_bound_row_idx {0}; 
-        int lower_bound_col_idx {0};
-        int upper_bound_row_idx {kNumRimgRow - 1}; 
-        int upper_bound_col_idx {kNumRimgCol - 1};
-        int pixel_idx_row = int(std::min(std::max(std::round(kNumRimgRow * (1 - (rad2deg(sph_point.el) + (kVFOV/float(2.0))) / (kVFOV - float(0.0)))), float(lower_bound_row_idx)), float(upper_bound_row_idx)));
-        int pixel_idx_col = int(std::min(std::max(std::round(kNumRimgCol * ((rad2deg(sph_point.az) + (kHFOV/float(2.0))) / (kHFOV - float(0.0)))), float(lower_bound_col_idx)), float(upper_bound_col_idx)));
-
-        float curr_range = sph_point.r;
-
-        // @ Theoretically, this if-block would have race condition (i.e., this is a critical section), 
-        // @ But, the resulting range image is acceptable (watching via Rviz), 
-        // @      so I just naively applied omp pragma for this whole for-block (2020.10.28)
-        // @ Reason: because this for loop is splited by the omp, points in a single splited for range do not race among them, 
-        // @         also, a point A and B lied in different for-segments do not tend to correspond to the same pixel, 
-        // #               so we can assume practically there are few race conditions.     
-        // @ P.S. some explicit mutexing directive makes the code even slower ref: https://stackoverflow.com/questions/2396430/how-to-use-lock-in-openmp
-        if ( curr_range < rimg.at<float>(pixel_idx_row, pixel_idx_col) ) {
-            rimg.at<float>(pixel_idx_row, pixel_idx_col) = curr_range;
-        }
-    }
-
-    return rimg;
-} // scan2RangeImg
-
-
-void Removerter::mergeScansWithinGlobalCoord( 
-        const std::vector<pcl::PointCloud<PointType>::Ptr>& _scans, 
-        const std::vector<Eigen::Matrix4d>& _scans_poses,
-        pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save )
-{
-    // NOTE: _scans must be in local coord
-    for(std::size_t scan_idx = 0 ; scan_idx < _scans.size(); scan_idx++)
+    // cout for debug
+    cout_counter++;
+    if (remainder(cout_counter, cout_interval) == 0)
     {
-        auto ii_scan = _scans.at(scan_idx); // pcl::PointCloud<PointType>::Ptr
-        auto ii_pose = _scans_poses.at(scan_idx); // Eigen::Matrix4d 
-
-        // local to global (local2global)
-        pcl::PointCloud<PointType>::Ptr scan_global_coord(new pcl::PointCloud<PointType>());
-        pcl::transformPointCloud(*ii_scan, *scan_global_coord, kSE3MatExtrinsicLiDARtoPoseBase);
-        pcl::transformPointCloud(*scan_global_coord, *scan_global_coord, ii_pose);
-
-        // merge the scan into the global map
-        *_ptcloud_to_save += *scan_global_coord;
+      cout << _scan_path << endl;
+      cout << "Read a pointcloud with " << points->points.size() << " points." << endl;
+      cout << "downsample the pointcloud: " << downsampled_points->points.size() << " points." << endl;
+      cout << " ... (display every " << cout_interval << " readings) ..." << endl;
     }
-} // mergeScansWithinGlobalCoord
+  }
+  cout << endl;
+}  // readValidScans
 
+std::pair<cv::Mat, cv::Mat> Removerter::map2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan,
+                                                     const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25,
+                                                                                            lower 25), hfov = 360] */
+                                                     const std::pair<int, int> _rimg_size)
+{
+  const float kVFOV = _fov.first;
+  const float kHFOV = _fov.second;
+
+  const int kNumRimgRow = _rimg_size.first;
+  const int kNumRimgCol = _rimg_size.second;
+
+  // @ range image initizliation
+  cv::Mat rimg =
+      cv::Mat(kNumRimgRow, kNumRimgCol, CV_32FC1, cv::Scalar::all(kFlagNoPOINT));  // float matrix, save range value
+  cv::Mat rimg_ptidx =
+      cv::Mat(kNumRimgRow, kNumRimgCol, CV_32SC1, cv::Scalar::all(0));  // int matrix, save point (of global map) index
+
+  // @ points to range img
+  int num_points = _scan->points.size();
+#pragma omp parallel for num_threads(kNumOmpCores)
+  for (int pt_idx = 0; pt_idx < num_points; ++pt_idx)
+  {
+    PointType this_point = _scan->points[pt_idx];
+    SphericalPoint sph_point = cart2sph(this_point);
+
+    // @ note about vfov: e.g., (+ V_FOV/2) to adjust [-15, 15] to [0, 30]
+    // @ min and max is just for the easier (naive) boundary checks.
+    int lower_bound_row_idx{ 0 };
+    int lower_bound_col_idx{ 0 };
+    int upper_bound_row_idx{ kNumRimgRow - 1 };
+    int upper_bound_col_idx{ kNumRimgCol - 1 };
+    int pixel_idx_row = int(std::min(
+        std::max(std::round(kNumRimgRow * (1 - (rad2deg(sph_point.el) + (kVFOV / float(2.0))) / (kVFOV - float(0.0)))),
+                 float(lower_bound_row_idx)),
+        float(upper_bound_row_idx)));
+    int pixel_idx_col = int(std::min(
+        std::max(std::round(kNumRimgCol * ((rad2deg(sph_point.az) + (kHFOV / float(2.0))) / (kHFOV - float(0.0)))),
+                 float(lower_bound_col_idx)),
+        float(upper_bound_col_idx)));
+
+    float curr_range = sph_point.r;
+
+    // @ Theoretically, this if-block would have race condition (i.e., this is a critical section),
+    // @ But, the resulting range image is acceptable (watching via Rviz),
+    // @      so I just naively applied omp pragma for this whole for-block (2020.10.28)
+    // @ Reason: because this for loop is splited by the omp, points in a single splited for range do not race among
+    // them,
+    // @         also, a point A and B lied in different for-segments do not tend to correspond to the same pixel,
+    // #               so we can assume practically there are few race conditions.
+    // @ P.S. some explicit mutexing directive makes the code even slower ref:
+    // https://stackoverflow.com/questions/2396430/how-to-use-lock-in-openmp
+    if (curr_range < rimg.at<float>(pixel_idx_row, pixel_idx_col))
+    {
+      rimg.at<float>(pixel_idx_row, pixel_idx_col) = curr_range;
+      rimg_ptidx.at<int>(pixel_idx_row, pixel_idx_col) = pt_idx;
+    }
+  }
+
+  return std::pair<cv::Mat, cv::Mat>(rimg, rimg_ptidx);
+}  // map2RangeImg
+
+cv::Mat Removerter::scan2RangeImg(const pcl::PointCloud<PointType>::Ptr& _scan,
+                                  const std::pair<float, float> _fov, /* e.g., [vfov = 50 (upper 25, lower 25), hfov =
+                                                                         360] */
+                                  const std::pair<int, int> _rimg_size)
+{
+  const float kVFOV = _fov.first;
+  const float kHFOV = _fov.second;
+
+  const int kNumRimgRow = _rimg_size.first;
+  const int kNumRimgCol = _rimg_size.second;
+  // cout << "rimg size is: [" << _rimg_size.first << ", " << _rimg_size.second << "]." << endl;
+
+  // @ range image initizliation
+  cv::Mat rimg = cv::Mat(kNumRimgRow, kNumRimgCol, CV_32FC1, cv::Scalar::all(kFlagNoPOINT));  // float matrix
+
+  // @ points to range img
+  int num_points = _scan->points.size();
+#pragma omp parallel for num_threads(kNumOmpCores)
+  for (int pt_idx = 0; pt_idx < num_points; ++pt_idx)
+  {
+    PointType this_point = _scan->points[pt_idx];
+    SphericalPoint sph_point = cart2sph(this_point);
+
+    // @ note about vfov: e.g., (+ V_FOV/2) to adjust [-15, 15] to [0, 30]
+    // @ min and max is just for the easier (naive) boundary checks.
+    int lower_bound_row_idx{ 0 };
+    int lower_bound_col_idx{ 0 };
+    int upper_bound_row_idx{ kNumRimgRow - 1 };
+    int upper_bound_col_idx{ kNumRimgCol - 1 };
+    int pixel_idx_row = int(std::min(
+        std::max(std::round(kNumRimgRow * (1 - (rad2deg(sph_point.el) + (kVFOV / float(2.0))) / (kVFOV - float(0.0)))),
+                 float(lower_bound_row_idx)),
+        float(upper_bound_row_idx)));
+    int pixel_idx_col = int(std::min(
+        std::max(std::round(kNumRimgCol * ((rad2deg(sph_point.az) + (kHFOV / float(2.0))) / (kHFOV - float(0.0)))),
+                 float(lower_bound_col_idx)),
+        float(upper_bound_col_idx)));
+
+    float curr_range = sph_point.r;
+
+    // @ Theoretically, this if-block would have race condition (i.e., this is a critical section),
+    // @ But, the resulting range image is acceptable (watching via Rviz),
+    // @      so I just naively applied omp pragma for this whole for-block (2020.10.28)
+    // @ Reason: because this for loop is splited by the omp, points in a single splited for range do not race among
+    // them,
+    // @         also, a point A and B lied in different for-segments do not tend to correspond to the same pixel,
+    // #               so we can assume practically there are few race conditions.
+    // @ P.S. some explicit mutexing directive makes the code even slower ref:
+    // https://stackoverflow.com/questions/2396430/how-to-use-lock-in-openmp
+    if (curr_range < rimg.at<float>(pixel_idx_row, pixel_idx_col))
+    {
+      rimg.at<float>(pixel_idx_row, pixel_idx_col) = curr_range;
+    }
+  }
+
+  return rimg;
+}  // scan2RangeImg
+
+void Removerter::mergeScansWithinGlobalCoord(const std::vector<pcl::PointCloud<PointType>::Ptr>& _scans,
+                                             const std::vector<Eigen::Matrix4d>& _scans_poses,
+                                             pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save)
+{
+  // NOTE: _scans must be in local coord
+  for (std::size_t scan_idx = 0; scan_idx < _scans.size(); scan_idx++)
+  {
+    auto ii_scan = _scans.at(scan_idx);        // pcl::PointCloud<PointType>::Ptr
+    auto ii_pose = _scans_poses.at(scan_idx);  // Eigen::Matrix4d
+
+    // local to global (local2global)
+    pcl::PointCloud<PointType>::Ptr scan_global_coord(new pcl::PointCloud<PointType>());
+    pcl::transformPointCloud(*ii_scan, *scan_global_coord, kSE3MatExtrinsicLiDARtoPoseBase);
+    pcl::transformPointCloud(*scan_global_coord, *scan_global_coord, ii_pose);
+
+    // merge the scan into the global map
+    *_ptcloud_to_save += *scan_global_coord;
+  }
+}  // mergeScansWithinGlobalCoord
 
 void Removerter::Downsampling(const pcl::PointCloud<PointType>::Ptr& _src, pcl::PointCloud<PointType>::Ptr& _to_save)
 {
-    if(use_rgb)
-    {
-        pcl::VoxelGrid<PointType> downsize_filter;
-        downsize_filter.setLeafSize(kDownsampleVoxelSize, kDownsampleVoxelSize, kDownsampleVoxelSize);
-        downsize_filter.setInputCloud(_src);
-        downsize_filter.filter(*_to_save);
-    }
-    else
-    {
-        pcl::octree::OctreePointCloudVoxelCentroid<PointType> octree( kDownsampleVoxelSize );
-        octree.setInputCloud(_src);
-        octree.defineBoundingBox();
-        octree.addPointsFromInputCloud();
-        pcl::octree::OctreePointCloudVoxelCentroid<PointType>::AlignedPointTVector centroids;
-        octree.getVoxelCentroids(centroids);
+  if (use_rgb)
+  {
+    pcl::VoxelGrid<PointType> downsize_filter;
+    downsize_filter.setLeafSize(kDownsampleVoxelSize, kDownsampleVoxelSize, kDownsampleVoxelSize);
+    downsize_filter.setInputCloud(_src);
+    downsize_filter.filter(*_to_save);
+  }
+  else
+  {
+    pcl::octree::OctreePointCloudVoxelCentroid<PointType> octree(kDownsampleVoxelSize);
+    octree.setInputCloud(_src);
+    octree.defineBoundingBox();
+    octree.addPointsFromInputCloud();
+    pcl::octree::OctreePointCloudVoxelCentroid<PointType>::AlignedPointTVector centroids;
+    octree.getVoxelCentroids(centroids);
 
-        // init current map with the downsampled full cloud 
-        _to_save->points.assign(centroids.begin(), centroids.end());    
-        _to_save->width = 1; 
-        _to_save->height = _to_save->points.size(); // make sure again the format of the downsampled point cloud 
-    }
-    ROS_INFO_STREAM("\033[1;32m Downsampled pointcloud have: " << _to_save->points.size() << " points.\033[0m");   
-    cout << endl;
-} // Downsampling
-
+    // init current map with the downsampled full cloud
+    _to_save->points.assign(centroids.begin(), centroids.end());
+    _to_save->width = 1;
+    _to_save->height = _to_save->points.size();  // make sure again the format of the downsampled point cloud
+  }
+  ROS_INFO_STREAM("\033[1;32m Downsampled pointcloud have: " << _to_save->points.size() << " points.\033[0m");
+  cout << endl;
+}  // Downsampling
 
 void Removerter::savePCD(std::string file_name, pcl::PointCloud<PointType>::Ptr cloud)
 {
-    if(use_rgb)
+  if (use_rgb)
+  {
+    pcl::io::savePCDFileBinary(file_name, *cloud);
+  }
+  else
+  {
+    pcl::PointCloud<pcl::PointXYZI>::Ptr save_cloud(new pcl::PointCloud<pcl::PointXYZI>());
+    int cloudSize = cloud->size();
+    save_cloud->resize(cloudSize);
+
+    for (int i = 0; i < cloudSize; ++i)
     {
-        pcl::io::savePCDFileBinary(file_name, *cloud);
+      const auto& pointFrom = cloud->points[i];
+      save_cloud->points[i].x = pointFrom.x;
+      save_cloud->points[i].y = pointFrom.y;
+      save_cloud->points[i].z = pointFrom.z;
+      save_cloud->points[i].intensity = pointFrom.intensity;
     }
-    else
-    {
-        pcl::PointCloud<pcl::PointXYZI>::Ptr save_cloud(new pcl::PointCloud<pcl::PointXYZI>());
-        int cloudSize = cloud->size();
-        save_cloud->resize(cloudSize);
 
-        for (int i = 0; i < cloudSize; ++i)
-        {
-            const auto& pointFrom = cloud->points[i];
-            save_cloud->points[i].x = pointFrom.x;
-            save_cloud->points[i].y = pointFrom.y;
-            save_cloud->points[i].z = pointFrom.z;
-            save_cloud->points[i].intensity = pointFrom.intensity;
-        }
-        
-        pcl::io::savePCDFileBinary(file_name, *save_cloud);
-    }
-} // savePCD
+    pcl::io::savePCDFileBinary(file_name, *save_cloud);
+  }
+}  // savePCD
 
-
-void Removerter::makeGlobalMap( void )
+void Removerter::makeGlobalMap(void)
 {
-    // transform local to global and merging the scans 
-    map_global_orig_->clear();
-    map_global_curr_->clear();
+  // transform local to global and merging the scans
+  map_global_orig_->clear();
+  map_global_curr_->clear();
 
-    mergeScansWithinGlobalCoord(scans_, scan_poses_, map_global_orig_);
-    ROS_INFO_STREAM("\033[1;32m Map pointcloud (having redundant points) have: " << map_global_orig_->points.size() << " points.\033[0m");   
-    ROS_INFO_STREAM("\033[1;32m Downsampling leaf size is " << kDownsampleVoxelSize << " m.\033[0m"); 
+  mergeScansWithinGlobalCoord(scans_, scan_poses_, map_global_orig_);
+  ROS_INFO_STREAM("\033[1;32m Map pointcloud (having redundant points) have: " << map_global_orig_->points.size()
+                                                                               << " points.\033[0m");
+  ROS_INFO_STREAM("\033[1;32m Downsampling leaf size is " << kDownsampleVoxelSize << " m.\033[0m");
 
-    // remove repeated (redundant) points
-    // - using OctreePointCloudVoxelCentroid for downsampling 
-    // - For a large-size point cloud should use OctreePointCloudVoxelCentroid rather VoxelGrid
-    Downsampling(map_global_orig_, map_global_curr_);
+  // remove repeated (redundant) points
+  // - using OctreePointCloudVoxelCentroid for downsampling
+  // - For a large-size point cloud should use OctreePointCloudVoxelCentroid rather VoxelGrid
+  Downsampling(map_global_orig_, map_global_curr_);
 
-    // save the original cloud 
-    if( kFlagSaveMapPointcloud ) {
-        // in global coord
-        std::string static_global_file_name = save_pcd_directory_ + "OriginalNoisyMapGlobal.pcd";
-        savePCD(static_global_file_name, map_global_curr_);
-        ROS_INFO_STREAM("\033[1;32m The original pointcloud is saved (global coord): " << static_global_file_name << "\033[0m");   
+  // save the original cloud
+  if (kFlagSaveMapPointcloud)
+  {
+    // in global coord
+    std::string static_global_file_name = save_pcd_directory_ + "OriginalNoisyMapGlobal.pcd";
+    savePCD(static_global_file_name, map_global_curr_);
+    ROS_INFO_STREAM("\033[1;32m The original pointcloud is saved (global coord): " << static_global_file_name
+                                                                                   << "\033[0m");
 
-        // in local coord (i.e., base_node_idx == 0 means a start idx is the identity pose)
-        int base_node_idx = base_node_idx_;    
-        pcl::PointCloud<PointType>::Ptr map_local_curr (new pcl::PointCloud<PointType>);
-        transformGlobalMapToLocal(map_global_curr_, base_node_idx, map_local_curr);
-        std::string static_local_file_name = save_pcd_directory_ + "OriginalNoisyMapLocal.pcd";
-        savePCD(static_local_file_name, map_local_curr);
-        ROS_INFO_STREAM("\033[1;32m The original pointcloud is saved (local coord): " << static_local_file_name << "\033[0m");   
-    }
-    // make tree (for fast ball search for the projection to make a map range image later)
-    // if(kUseSubsetMapCloud) // NOT recommend to use for under 5 million points map input
-    //     kdtree_map_global_curr_->setInputCloud(map_global_curr_);
+    // in local coord (i.e., base_node_idx == 0 means a start idx is the identity pose)
+    int base_node_idx = base_node_idx_;
+    pcl::PointCloud<PointType>::Ptr map_local_curr(new pcl::PointCloud<PointType>);
+    transformGlobalMapToLocal(map_global_curr_, base_node_idx, map_local_curr);
+    std::string static_local_file_name = save_pcd_directory_ + "OriginalNoisyMapLocal.pcd";
+    savePCD(static_local_file_name, map_local_curr);
+    ROS_INFO_STREAM("\033[1;32m The original pointcloud is saved (local coord): " << static_local_file_name
+                                                                                  << "\033[0m");
+  }
+  // make tree (for fast ball search for the projection to make a map range image later)
+  // if(kUseSubsetMapCloud) // NOT recommend to use for under 5 million points map input
+  //     kdtree_map_global_curr_->setInputCloud(map_global_curr_);
 
-    // save current map into history
-    // TODO
-    // if(save_history_on_memory_)
-    //     saveCurrentStaticMapHistory();
+  // save current map into history
+  // TODO
+  // if(save_history_on_memory_)
+  //     saveCurrentStaticMapHistory();
 
-} // makeGlobalMap
- 
+}  // makeGlobalMap
 
 void Removerter::transformGlobalMapSubsetToLocal(int _base_scan_idx)
 {
-    Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
-    
-    // global to local (global2local)
-    map_local_curr_->clear();
-    pcl::transformPointCloud(*map_subset_global_curr_, *map_local_curr_, base_pose_inverse);
-    pcl::transformPointCloud(*map_local_curr_, *map_local_curr_, kSE3MatExtrinsicPoseBasetoLiDAR);
+  Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
 
-} // transformGlobalMapSubsetToLocal
+  // global to local (global2local)
+  map_local_curr_->clear();
+  pcl::transformPointCloud(*map_subset_global_curr_, *map_local_curr_, base_pose_inverse);
+  pcl::transformPointCloud(*map_local_curr_, *map_local_curr_, kSE3MatExtrinsicPoseBasetoLiDAR);
 
+}  // transformGlobalMapSubsetToLocal
 
 void Removerter::transformGlobalMapToLocal(int _base_scan_idx)
 {
-    Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
-    
-    // global to local (global2local)
-    map_local_curr_->clear();
-    pcl::transformPointCloud(*map_global_curr_, *map_local_curr_, base_pose_inverse);
-    pcl::transformPointCloud(*map_local_curr_, *map_local_curr_, kSE3MatExtrinsicPoseBasetoLiDAR);
+  Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
 
-} // transformGlobalMapToLocal
+  // global to local (global2local)
+  map_local_curr_->clear();
+  pcl::transformPointCloud(*map_global_curr_, *map_local_curr_, base_pose_inverse);
+  pcl::transformPointCloud(*map_local_curr_, *map_local_curr_, kSE3MatExtrinsicPoseBasetoLiDAR);
 
+}  // transformGlobalMapToLocal
 
 void Removerter::transformGlobalMapToLocal(int _base_scan_idx, pcl::PointCloud<PointType>::Ptr& _map_local)
 {
-    Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
-    
-    // global to local (global2local)
-    _map_local->clear();
-    pcl::transformPointCloud(*map_global_curr_, *_map_local, base_pose_inverse);
-    pcl::transformPointCloud(*_map_local, *_map_local, kSE3MatExtrinsicPoseBasetoLiDAR);
+  Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
 
-} // transformGlobalMapToLocal
+  // global to local (global2local)
+  _map_local->clear();
+  pcl::transformPointCloud(*map_global_curr_, *_map_local, base_pose_inverse);
+  pcl::transformPointCloud(*_map_local, *_map_local, kSE3MatExtrinsicPoseBasetoLiDAR);
 
+}  // transformGlobalMapToLocal
 
-void Removerter::transformGlobalMapToLocal(
-    const pcl::PointCloud<PointType>::Ptr& _map_global, 
-    int _base_scan_idx, pcl::PointCloud<PointType>::Ptr& _map_local)
+void Removerter::transformGlobalMapToLocal(const pcl::PointCloud<PointType>::Ptr& _map_global, int _base_scan_idx,
+                                           pcl::PointCloud<PointType>::Ptr& _map_local)
 {
-    Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
-    
-    // global to local (global2local)
-    _map_local->clear();
-    pcl::transformPointCloud(*_map_global, *_map_local, base_pose_inverse);
-    pcl::transformPointCloud(*_map_local, *_map_local, kSE3MatExtrinsicPoseBasetoLiDAR);
+  Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_base_scan_idx);
 
-} // transformGlobalMapToLocal
+  // global to local (global2local)
+  _map_local->clear();
+  pcl::transformPointCloud(*_map_global, *_map_local, base_pose_inverse);
+  pcl::transformPointCloud(*_map_local, *_map_local, kSE3MatExtrinsicPoseBasetoLiDAR);
 
+}  // transformGlobalMapToLocal
 
-void Removerter::parseMapPointcloudSubsetUsingPtIdx( std::vector<int>& _point_indexes, pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save ) 
+void Removerter::parseMapPointcloudSubsetUsingPtIdx(std::vector<int>& _point_indexes,
+                                                    pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save)
 {
-    // extractor
-    pcl::ExtractIndices<PointType> extractor;
-    boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
-    extractor.setInputCloud(map_global_curr_); 
-    extractor.setIndices(index_ptr);
-    extractor.setNegative(false); // If set to true, you can extract point clouds outside the specified index
+  // extractor
+  pcl::ExtractIndices<PointType> extractor;
+  boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
+  extractor.setInputCloud(map_global_curr_);
+  extractor.setIndices(index_ptr);
+  extractor.setNegative(false);  // If set to true, you can extract point clouds outside the specified index
 
-    // parse 
-    _ptcloud_to_save->clear();
-    extractor.filter(*_ptcloud_to_save);
-} // parseMapPointcloudSubsetUsingPtIdx
+  // parse
+  _ptcloud_to_save->clear();
+  extractor.filter(*_ptcloud_to_save);
+}  // parseMapPointcloudSubsetUsingPtIdx
 
-
-void Removerter::parseStaticMapPointcloudUsingPtIdx( std::vector<int>& _point_indexes ) 
+void Removerter::parseStaticMapPointcloudUsingPtIdx(std::vector<int>& _point_indexes)
 {
-    // extractor
-    pcl::ExtractIndices<PointType> extractor;
-    boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
-    extractor.setInputCloud(map_global_curr_); 
-    extractor.setIndices(index_ptr);
-    extractor.setNegative(false); // If set to true, you can extract point clouds outside the specified index
+  // extractor
+  pcl::ExtractIndices<PointType> extractor;
+  boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
+  extractor.setInputCloud(map_global_curr_);
+  extractor.setIndices(index_ptr);
+  extractor.setNegative(false);  // If set to true, you can extract point clouds outside the specified index
 
-    // parse 
-    map_global_curr_static_->clear();
-    extractor.filter(*map_global_curr_static_);
-} // parseStaticMapPointcloudUsingPtIdx
+  // parse
+  map_global_curr_static_->clear();
+  extractor.filter(*map_global_curr_static_);
+}  // parseStaticMapPointcloudUsingPtIdx
 
-
-void Removerter::parseDynamicMapPointcloudUsingPtIdx( std::vector<int>& _point_indexes )
+void Removerter::parseDynamicMapPointcloudUsingPtIdx(std::vector<int>& _point_indexes)
 {
-    // extractor
-    pcl::ExtractIndices<PointType> extractor;
-    boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
-    extractor.setInputCloud(map_global_curr_); 
-    extractor.setIndices(index_ptr);
-    extractor.setNegative(false); // If set to true, you can extract point clouds outside the specified index
+  // extractor
+  pcl::ExtractIndices<PointType> extractor;
+  boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
+  extractor.setInputCloud(map_global_curr_);
+  extractor.setIndices(index_ptr);
+  extractor.setNegative(false);  // If set to true, you can extract point clouds outside the specified index
 
-    // parse 
-    map_global_curr_dynamic_->clear();
-    extractor.filter(*map_global_curr_dynamic_);
-} // parseDynamicMapPointcloudUsingPtIdx
+  // parse
+  map_global_curr_dynamic_->clear();
+  extractor.filter(*map_global_curr_dynamic_);
+}  // parseDynamicMapPointcloudUsingPtIdx
 
-
-void Removerter::saveCurrentStaticAndDynamicPointCloudGlobal( void )
+void Removerter::saveCurrentStaticAndDynamicPointCloudGlobal(void)
 {
-    if( ! kFlagSaveMapPointcloud )
-        return;
+  if (!kFlagSaveMapPointcloud)
+    return;
 
-    std::string curr_res_alpha_str = std::to_string(curr_res_alpha_);
+  std::string curr_res_alpha_str = std::to_string(curr_res_alpha_);
 
-    // dynamic 
-    std::string dyna_file_name = map_dynamic_save_dir_ + "/DynamicMapMapsideGlobalResX" + curr_res_alpha_str + ".pcd";
-    savePCD(dyna_file_name, map_global_curr_dynamic_);
-    ROS_INFO_STREAM("\033[1;32m -- a pointcloud is saved: " << dyna_file_name << "\033[0m");   
+  // dynamic
+  std::string dyna_file_name = map_dynamic_save_dir_ + "/DynamicMapMapsideGlobalResX" + curr_res_alpha_str + ".pcd";
+  savePCD(dyna_file_name, map_global_curr_dynamic_);
+  ROS_INFO_STREAM("\033[1;32m -- a pointcloud is saved: " << dyna_file_name << "\033[0m");
 
-    // static 
-    std::string static_file_name = map_static_save_dir_ + "/StaticMapMapsideGlobalResX" + curr_res_alpha_str + ".pcd";
-    savePCD(static_file_name, map_global_curr_static_);
-    ROS_INFO_STREAM("\033[1;32m -- a pointcloud is saved: " << static_file_name << "\033[0m");   
-} // saveCurrentStaticAndDynamicPointCloudGlobal
+  // static
+  std::string static_file_name = map_static_save_dir_ + "/StaticMapMapsideGlobalResX" + curr_res_alpha_str + ".pcd";
+  savePCD(static_file_name, map_global_curr_static_);
+  ROS_INFO_STREAM("\033[1;32m -- a pointcloud is saved: " << static_file_name << "\033[0m");
+}  // saveCurrentStaticAndDynamicPointCloudGlobal
 
-
-void Removerter::saveCurrentStaticAndDynamicPointCloudLocal( int _base_node_idx )
+void Removerter::saveCurrentStaticAndDynamicPointCloudLocal(int _base_node_idx)
 {
-    if( ! kFlagSaveMapPointcloud )
-        return;
+  if (!kFlagSaveMapPointcloud)
+    return;
 
-    std::string curr_res_alpha_str = std::to_string(curr_res_alpha_);
+  std::string curr_res_alpha_str = std::to_string(curr_res_alpha_);
 
-    // dynamic 
-    pcl::PointCloud<PointType>::Ptr map_local_curr_dynamic (new pcl::PointCloud<PointType>);
-    transformGlobalMapToLocal(map_global_curr_dynamic_, _base_node_idx, map_local_curr_dynamic);
-    std::string dyna_file_name = map_dynamic_save_dir_ + "/DynamicMapMapsideLocalResX" + curr_res_alpha_str + ".pcd";
-    savePCD(dyna_file_name, map_local_curr_dynamic);
-    ROS_INFO_STREAM("\033[1;32m -- a pointcloud is saved: " << dyna_file_name << "\033[0m");   
+  // dynamic
+  pcl::PointCloud<PointType>::Ptr map_local_curr_dynamic(new pcl::PointCloud<PointType>);
+  transformGlobalMapToLocal(map_global_curr_dynamic_, _base_node_idx, map_local_curr_dynamic);
+  std::string dyna_file_name = map_dynamic_save_dir_ + "/DynamicMapMapsideLocalResX" + curr_res_alpha_str + ".pcd";
+  savePCD(dyna_file_name, map_local_curr_dynamic);
+  ROS_INFO_STREAM("\033[1;32m -- a pointcloud is saved: " << dyna_file_name << "\033[0m");
 
-    // static 
-    pcl::PointCloud<PointType>::Ptr map_local_curr_static (new pcl::PointCloud<PointType>);
-    transformGlobalMapToLocal(map_global_curr_static_, _base_node_idx, map_local_curr_static);
-    std::string static_file_name = map_static_save_dir_ + "/StaticMapMapsideLocalResX" + curr_res_alpha_str + ".pcd";
-    savePCD(static_file_name, map_local_curr_static);
-    ROS_INFO_STREAM("\033[1;32m -- a pointcloud is saved: " << static_file_name << "\033[0m");   
+  // static
+  pcl::PointCloud<PointType>::Ptr map_local_curr_static(new pcl::PointCloud<PointType>);
+  transformGlobalMapToLocal(map_global_curr_static_, _base_node_idx, map_local_curr_static);
+  std::string static_file_name = map_static_save_dir_ + "/StaticMapMapsideLocalResX" + curr_res_alpha_str + ".pcd";
+  savePCD(static_file_name, map_local_curr_static);
+  ROS_INFO_STREAM("\033[1;32m -- a pointcloud is saved: " << static_file_name << "\033[0m");
 
-} // saveCurrentStaticAndDynamicPointCloudLocal
+}  // saveCurrentStaticAndDynamicPointCloudLocal
 
-
-std::vector<int> Removerter::calcDescrepancyAndParseDynamicPointIdx
-    (const cv::Mat& _scan_rimg, const cv::Mat& _diff_rimg, const cv::Mat& _map_rimg_ptidx)
+std::vector<int> Removerter::calcDescrepancyAndParseDynamicPointIdx(const cv::Mat& _scan_rimg,
+                                                                    const cv::Mat& _diff_rimg,
+                                                                    const cv::Mat& _map_rimg_ptidx)
 {
-    int num_dyna_points {0}; // TODO: tracking the number of dynamic-assigned points and decide when to stop removing (currently just fixed iteration e.g., [2.5, 2.0, 1.5])
+  int num_dyna_points{ 0 };  // TODO: tracking the number of dynamic-assigned points and decide when to stop removing
+                             // (currently just fixed iteration e.g., [2.5, 2.0, 1.5])
 
-    std::vector<int> dynamic_point_indexes;
-    for (int row_idx = 0; row_idx < _diff_rimg.rows; row_idx++) {
-        for (int col_idx = 0; col_idx < _diff_rimg.cols; col_idx++) {
-            float this_diff = _diff_rimg.at<float>(row_idx, col_idx);
-            float this_range = _scan_rimg.at<float>(row_idx, col_idx);
+  std::vector<int> dynamic_point_indexes;
+  for (int row_idx = 0; row_idx < _diff_rimg.rows; row_idx++)
+  {
+    for (int col_idx = 0; col_idx < _diff_rimg.cols; col_idx++)
+    {
+      float this_diff = _diff_rimg.at<float>(row_idx, col_idx);
+      float this_range = _scan_rimg.at<float>(row_idx, col_idx);
 
-            float adaptive_coeff = 0.05; // meter, // i.e., if 4m apart point, it should be 0.4m be diff (nearer) wrt the query
-            float adaptive_dynamic_descrepancy_threshold = adaptive_coeff * this_range; // adaptive descrepancy threshold 
-            // float adaptive_dynamic_descrepancy_threshold = 0.1;
+      float adaptive_coeff =
+          0.05;  // meter, // i.e., if 4m apart point, it should be 0.4m be diff (nearer) wrt the query
+      float adaptive_dynamic_descrepancy_threshold = adaptive_coeff * this_range;  // adaptive descrepancy threshold
+      // float adaptive_dynamic_descrepancy_threshold = 0.1;
 
-            if( this_diff < kValidDiffUpperBound // exclude no-point pixels either on scan img or map img (100 is roughly 100 meter)
-                && this_diff > adaptive_dynamic_descrepancy_threshold /* dynamic */) 
-            {  // dynamic
-                int this_point_idx_in_global_map = _map_rimg_ptidx.at<int>(row_idx, col_idx);
-                dynamic_point_indexes.emplace_back(this_point_idx_in_global_map);
+      if (this_diff < kValidDiffUpperBound  // exclude no-point pixels either on scan img or map img (100 is roughly 100
+                                            // meter)
+          && this_diff > adaptive_dynamic_descrepancy_threshold /* dynamic */)
+      {  // dynamic
+        int this_point_idx_in_global_map = _map_rimg_ptidx.at<int>(row_idx, col_idx);
+        dynamic_point_indexes.emplace_back(this_point_idx_in_global_map);
 
-                // num_dyna_points++; // TODO
-            } 
-        } 
+        // num_dyna_points++; // TODO
+      }
     }
+  }
 
-    return dynamic_point_indexes;
-} // calcDescrepancyAndParseDynamicPointIdx
+  return dynamic_point_indexes;
+}  // calcDescrepancyAndParseDynamicPointIdx
 
-
-void Removerter::takeGlobalMapSubsetWithinBall( int _center_scan_idx )
+void Removerter::takeGlobalMapSubsetWithinBall(int _center_scan_idx)
 {
-    Eigen::Matrix4d center_pose_se3 = scan_poses_.at(_center_scan_idx);
-    PointType center_pose;
-    center_pose.x = float(center_pose_se3(0, 3));
-    center_pose.y = float(center_pose_se3(1, 3));
-    center_pose.z = float(center_pose_se3(2, 3));
+  Eigen::Matrix4d center_pose_se3 = scan_poses_.at(_center_scan_idx);
+  PointType center_pose;
+  center_pose.x = float(center_pose_se3(0, 3));
+  center_pose.y = float(center_pose_se3(1, 3));
+  center_pose.z = float(center_pose_se3(2, 3));
 
-    std::vector<int> subset_indexes;
-    std::vector<float> pointSearchSqDisGlobalMap;
-    kdtree_map_global_curr_->radiusSearch(center_pose, kBallSize, subset_indexes, pointSearchSqDisGlobalMap, 0);
-    parseMapPointcloudSubsetUsingPtIdx(subset_indexes, map_subset_global_curr_);
-} // takeMapSubsetWithinBall
+  std::vector<int> subset_indexes;
+  std::vector<float> pointSearchSqDisGlobalMap;
+  kdtree_map_global_curr_->radiusSearch(center_pose, kBallSize, subset_indexes, pointSearchSqDisGlobalMap, 0);
+  parseMapPointcloudSubsetUsingPtIdx(subset_indexes, map_subset_global_curr_);
+}  // takeMapSubsetWithinBall
 
-
-std::vector<int> Removerter::calcDescrepancyAndParseDynamicPointIdxForEachScan( std::pair<int, int> _rimg_shape )
-{   
-    std::vector<int> dynamic_point_indexes;
-    // dynamic_point_indexes.reserve(100000);
-    for(std::size_t idx_scan=0; idx_scan < scans_.size(); ++idx_scan) {            
-        // curr scan 
-        pcl::PointCloud<PointType>::Ptr _scan = scans_.at(idx_scan);
-
-        // scan's pointcloud to range img 
-        cv::Mat scan_rimg = scan2RangeImg(_scan, kFOV, _rimg_shape); // openMP inside
-
-        // map's pointcloud to range img 
-        if( kUseSubsetMapCloud ) {
-            takeGlobalMapSubsetWithinBall(idx_scan);
-            transformGlobalMapSubsetToLocal(idx_scan); // the most time comsuming part 1 
-        } else {
-            // if the input map size (of a batch) is short, just using this line is more fast. 
-            // - e.g., 100-1000m or ~5 million points are ok, empirically more than 10Hz 
-            transformGlobalMapToLocal(idx_scan);
-        }
-        auto [map_rimg, map_rimg_ptidx] = map2RangeImg(map_local_curr_, kFOV, _rimg_shape); // the most time comsuming part 2 -> so openMP applied inside
-
-        // diff range img 
-        const int kNumRimgRow = _rimg_shape.first;
-        const int kNumRimgCol = _rimg_shape.second;
-        cv::Mat diff_rimg = cv::Mat(kNumRimgRow, kNumRimgCol, CV_32FC1, cv::Scalar::all(0.0)); // float matrix, save range value 
-        cv::absdiff(scan_rimg, map_rimg, diff_rimg);
-
-        // parse dynamic points' indexes: rule: If a pixel value of diff_rimg is larger, scan is the further - means that pixel of submap is likely dynamic.
-        std::vector<int> this_scan_dynamic_point_indexes = calcDescrepancyAndParseDynamicPointIdx(scan_rimg, diff_rimg, map_rimg_ptidx);
-        dynamic_point_indexes.insert(dynamic_point_indexes.end(), this_scan_dynamic_point_indexes.begin(), this_scan_dynamic_point_indexes.end());
-
-        // visualization 
-        pubRangeImg(scan_rimg, scan_rimg_msg_, scan_rimg_msg_publisher_, kRangeColorAxis);
-        pubRangeImg(map_rimg, map_rimg_msg_, map_rimg_msg_publisher_, kRangeColorAxis);
-        pubRangeImg(diff_rimg, diff_rimg_msg_, diff_rimg_msg_publisher_, kRangeColorAxisForDiff);
-
-        std::pair<float, float> kRangeColorAxisForPtIdx {0.0, float(map_global_curr_->points.size())};
-        pubRangeImg(map_rimg_ptidx, map_rimg_ptidx_msg_, map_rimg_ptidx_msg_publisher_, kRangeColorAxisForPtIdx);
-
-        publishPointcloud2FromPCLptr(scan_publisher_, _scan);
-    } // for_each scan Done
-
-    // remove repeated indexes
-    std::set<int> dynamic_point_indexes_set (dynamic_point_indexes.begin(), dynamic_point_indexes.end());
-    std::vector<int> dynamic_point_indexes_unique (dynamic_point_indexes_set.begin(), dynamic_point_indexes_set.end());
-
-    return dynamic_point_indexes_unique;
-} // calcDescrepancyForEachScan
-
-
-std::vector<int> Removerter::getStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes, int _num_all_points)
+std::vector<int> Removerter::calcDescrepancyAndParseDynamicPointIdxForEachScan(std::pair<int, int> _rimg_shape)
 {
-    std::vector<int> pt_idx_all = linspace<int>(0, _num_all_points, _num_all_points);
+  std::vector<int> dynamic_point_indexes;
+  // dynamic_point_indexes.reserve(100000);
+  for (std::size_t idx_scan = 0; idx_scan < scans_.size(); ++idx_scan)
+  {
+    // curr scan
+    pcl::PointCloud<PointType>::Ptr _scan = scans_.at(idx_scan);
 
-    std::set<int> pt_idx_all_set (pt_idx_all.begin(), pt_idx_all.end());
-    for(auto& _dyna_pt_idx: _dynamic_point_indexes) {
-        pt_idx_all_set.erase(_dyna_pt_idx);
+    // scan's pointcloud to range img
+    cv::Mat scan_rimg = scan2RangeImg(_scan, kFOV, _rimg_shape);  // openMP inside
+
+    // map's pointcloud to range img
+    if (kUseSubsetMapCloud)
+    {
+      takeGlobalMapSubsetWithinBall(idx_scan);
+      transformGlobalMapSubsetToLocal(idx_scan);  // the most time comsuming part 1
     }
+    else
+    {
+      // if the input map size (of a batch) is short, just using this line is more fast.
+      // - e.g., 100-1000m or ~5 million points are ok, empirically more than 10Hz
+      transformGlobalMapToLocal(idx_scan);
+    }
+    auto [map_rimg, map_rimg_ptidx] =
+        map2RangeImg(map_local_curr_, kFOV, _rimg_shape);  // the most time comsuming part 2 -> so openMP applied inside
 
-    std::vector<int> static_point_indexes (pt_idx_all_set.begin(), pt_idx_all_set.end());
-    return static_point_indexes;
-} // getStaticIdxFromDynamicIdx
+    // diff range img
+    const int kNumRimgRow = _rimg_shape.first;
+    const int kNumRimgCol = _rimg_shape.second;
+    cv::Mat diff_rimg =
+        cv::Mat(kNumRimgRow, kNumRimgCol, CV_32FC1, cv::Scalar::all(0.0));  // float matrix, save range value
+    cv::absdiff(scan_rimg, map_rimg, diff_rimg);
 
+    // parse dynamic points' indexes: rule: If a pixel value of diff_rimg is larger, scan is the further - means that
+    // pixel of submap is likely dynamic.
+    std::vector<int> this_scan_dynamic_point_indexes =
+        calcDescrepancyAndParseDynamicPointIdx(scan_rimg, diff_rimg, map_rimg_ptidx);
+    dynamic_point_indexes.insert(dynamic_point_indexes.end(), this_scan_dynamic_point_indexes.begin(),
+                                 this_scan_dynamic_point_indexes.end());
+
+    // visualization
+    pubRangeImg(scan_rimg, scan_rimg_msg_, scan_rimg_msg_publisher_, kRangeColorAxis);
+    pubRangeImg(map_rimg, map_rimg_msg_, map_rimg_msg_publisher_, kRangeColorAxis);
+    pubRangeImg(diff_rimg, diff_rimg_msg_, diff_rimg_msg_publisher_, kRangeColorAxisForDiff);
+
+    std::pair<float, float> kRangeColorAxisForPtIdx{ 0.0, float(map_global_curr_->points.size()) };
+    pubRangeImg(map_rimg_ptidx, map_rimg_ptidx_msg_, map_rimg_ptidx_msg_publisher_, kRangeColorAxisForPtIdx);
+
+    publishPointcloud2FromPCLptr(scan_publisher_, _scan);
+  }  // for_each scan Done
+
+  // remove repeated indexes
+  std::set<int> dynamic_point_indexes_set(dynamic_point_indexes.begin(), dynamic_point_indexes.end());
+  std::vector<int> dynamic_point_indexes_unique(dynamic_point_indexes_set.begin(), dynamic_point_indexes_set.end());
+
+  return dynamic_point_indexes_unique;
+}  // calcDescrepancyForEachScan
+
+std::vector<int> Removerter::getStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes,
+                                                        int _num_all_points)
+{
+  std::vector<int> pt_idx_all = linspace<int>(0, _num_all_points, _num_all_points);
+
+  std::set<int> pt_idx_all_set(pt_idx_all.begin(), pt_idx_all.end());
+  for (auto& _dyna_pt_idx : _dynamic_point_indexes)
+  {
+    pt_idx_all_set.erase(_dyna_pt_idx);
+  }
+
+  std::vector<int> static_point_indexes(pt_idx_all_set.begin(), pt_idx_all_set.end());
+  return static_point_indexes;
+}  // getStaticIdxFromDynamicIdx
 
 std::vector<int> Removerter::getGlobalMapStaticIdxFromDynamicIdx(const std::vector<int>& _dynamic_point_indexes)
 {
-    int num_all_points = map_global_curr_->points.size();
-    return getStaticIdxFromDynamicIdx(_dynamic_point_indexes, num_all_points);
-} // getGlobalMapStaticIdxFromDynamicIdx
-
-
+  int num_all_points = map_global_curr_->points.size();
+  return getStaticIdxFromDynamicIdx(_dynamic_point_indexes, num_all_points);
+}  // getGlobalMapStaticIdxFromDynamicIdx
 
 void Removerter::saveCurrentStaticMapHistory(void)
 {
-    // deep copy
-    pcl::PointCloud<PointType>::Ptr map_global_curr_static (new pcl::PointCloud<PointType>);
-    *map_global_curr_static = *map_global_curr_;  
+  // deep copy
+  pcl::PointCloud<PointType>::Ptr map_global_curr_static(new pcl::PointCloud<PointType>);
+  *map_global_curr_static = *map_global_curr_;
 
-    // save 
-    static_map_global_history_.emplace_back(map_global_curr_static);
-} // saveCurrentStaticMapHistory
+  // save
+  static_map_global_history_.emplace_back(map_global_curr_static);
+}  // saveCurrentStaticMapHistory
 
-
-void Removerter::removeOnce( float _res_alpha )
+void Removerter::removeOnce(float _res_alpha)
 {
-    // filter spec (i.e., a shape of the range image) 
-    curr_res_alpha_ = _res_alpha;
+  // filter spec (i.e., a shape of the range image)
+  curr_res_alpha_ = _res_alpha;
 
-    std::pair<int, int> rimg_shape = resetRimgSize(kFOV, _res_alpha);
-    float deg_per_pixel = 1.0 / _res_alpha;
-    ROS_INFO_STREAM("\033[1;32m Removing starts with resolution: x" << _res_alpha << " (" << deg_per_pixel << " deg/pixel)\033[0m");   
-    ROS_INFO_STREAM("\033[1;32m -- The range image size is: [" << rimg_shape.first << ", " << rimg_shape.second << "].\033[0m");   
-    ROS_INFO_STREAM("\033[1;32m -- The number of map points: " << map_global_curr_->points.size() << "\033[0m");  
-    ROS_INFO_STREAM("\033[1;32m -- ... starts cleaning ... " << "\033[0m");  
+  std::pair<int, int> rimg_shape = resetRimgSize(kFOV, _res_alpha);
+  float deg_per_pixel = 1.0 / _res_alpha;
+  ROS_INFO_STREAM("\033[1;32m Removing starts with resolution: x" << _res_alpha << " (" << deg_per_pixel
+                                                                  << " deg/pixel)\033[0m");
+  ROS_INFO_STREAM("\033[1;32m -- The range image size is: [" << rimg_shape.first << ", " << rimg_shape.second
+                                                             << "].\033[0m");
+  ROS_INFO_STREAM("\033[1;32m -- The number of map points: " << map_global_curr_->points.size() << "\033[0m");
+  ROS_INFO_STREAM("\033[1;32m -- ... starts cleaning ... "
+                  << "\033[0m");
 
-    // map-side removal: remove and get dynamic (will be removed) points' index set
-    std::vector<int> dynamic_point_indexes = calcDescrepancyAndParseDynamicPointIdxForEachScan( rimg_shape );
-    ROS_INFO_STREAM("\033[1;32m -- The number of dynamic points: " << dynamic_point_indexes.size() << "\033[0m"); 
-    parseDynamicMapPointcloudUsingPtIdx(dynamic_point_indexes);  
+  // map-side removal: remove and get dynamic (will be removed) points' index set
+  std::vector<int> dynamic_point_indexes = calcDescrepancyAndParseDynamicPointIdxForEachScan(rimg_shape);
+  ROS_INFO_STREAM("\033[1;32m -- The number of dynamic points: " << dynamic_point_indexes.size() << "\033[0m");
+  parseDynamicMapPointcloudUsingPtIdx(dynamic_point_indexes);
 
-    // static_point_indexes == complemently indexing dynamic_point_indexes
-    std::vector<int> static_point_indexes = getGlobalMapStaticIdxFromDynamicIdx(dynamic_point_indexes); 
-    ROS_INFO_STREAM("\033[1;32m -- The number of static points: " << static_point_indexes.size() << "\033[0m");  
-    parseStaticMapPointcloudUsingPtIdx(static_point_indexes);
+  // static_point_indexes == complemently indexing dynamic_point_indexes
+  std::vector<int> static_point_indexes = getGlobalMapStaticIdxFromDynamicIdx(dynamic_point_indexes);
+  ROS_INFO_STREAM("\033[1;32m -- The number of static points: " << static_point_indexes.size() << "\033[0m");
+  parseStaticMapPointcloudUsingPtIdx(static_point_indexes);
 
-    // Update the current map and reset the tree
-    map_global_curr_->clear();
-    *map_global_curr_ = *map_global_curr_static_;
+  // Update the current map and reset the tree
+  map_global_curr_->clear();
+  *map_global_curr_ = *map_global_curr_static_;
 
-    // if(kUseSubsetMapCloud) // NOT recommend to use for under 5 million points map input
-    //     kdtree_map_global_curr_->setInputCloud(map_global_curr_); 
+  // if(kUseSubsetMapCloud) // NOT recommend to use for under 5 million points map input
+  //     kdtree_map_global_curr_->setInputCloud(map_global_curr_);
 
-} // removeOnce
+}  // removeOnce
 
-
-void Removerter::revertOnce( float _res_alpha )
+void Removerter::revertOnce(float _res_alpha)
 {
-    std::pair<int, int> rimg_shape = resetRimgSize(kFOV, _res_alpha);
-    float deg_per_pixel = 1.0 / _res_alpha;    
-    ROS_INFO_STREAM("\033[1;32m Reverting starts with resolution: x" << _res_alpha << " (" << deg_per_pixel << " deg/pixel)\033[0m");   
-    ROS_INFO_STREAM("\033[1;32m -- The range image size is: [" << rimg_shape.first << ", " << rimg_shape.second << "].\033[0m");   
-    ROS_INFO_STREAM("\033[1;32m -- ... TODO ... \033[0m");   
+  std::pair<int, int> rimg_shape = resetRimgSize(kFOV, _res_alpha);
+  float deg_per_pixel = 1.0 / _res_alpha;
+  ROS_INFO_STREAM("\033[1;32m Reverting starts with resolution: x" << _res_alpha << " (" << deg_per_pixel
+                                                                   << " deg/pixel)\033[0m");
+  ROS_INFO_STREAM("\033[1;32m -- The range image size is: [" << rimg_shape.first << ", " << rimg_shape.second
+                                                             << "].\033[0m");
+  ROS_INFO_STREAM("\033[1;32m -- ... TODO ... \033[0m");
 
-    // TODO
+  // TODO
 
-} // revertOnce
+}  // revertOnce
 
-
-void Removerter::parsePointcloudSubsetUsingPtIdx( const pcl::PointCloud<PointType>::Ptr& _ptcloud_orig,
-            std::vector<int>& _point_indexes, pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save ) 
+void Removerter::parsePointcloudSubsetUsingPtIdx(const pcl::PointCloud<PointType>::Ptr& _ptcloud_orig,
+                                                 std::vector<int>& _point_indexes,
+                                                 pcl::PointCloud<PointType>::Ptr& _ptcloud_to_save)
 {
-    // extractor
-    pcl::ExtractIndices<PointType> extractor;
-    boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
-    extractor.setInputCloud(_ptcloud_orig); 
-    extractor.setIndices(index_ptr);
-    extractor.setNegative(false); // If set to true, you can extract point clouds outside the specified index
+  // extractor
+  pcl::ExtractIndices<PointType> extractor;
+  boost::shared_ptr<std::vector<int>> index_ptr = boost::make_shared<std::vector<int>>(_point_indexes);
+  extractor.setInputCloud(_ptcloud_orig);
+  extractor.setIndices(index_ptr);
+  extractor.setNegative(false);  // If set to true, you can extract point clouds outside the specified index
 
-    // parse 
-    _ptcloud_to_save->clear();
-    extractor.filter(*_ptcloud_to_save);
-} // parsePointcloudSubsetUsingPtIdx
+  // parse
+  _ptcloud_to_save->clear();
+  extractor.filter(*_ptcloud_to_save);
+}  // parsePointcloudSubsetUsingPtIdx
 
-
-pcl::PointCloud<PointType>::Ptr Removerter::local2global(const pcl::PointCloud<PointType>::Ptr& _scan_local, int _scan_idx)
+pcl::PointCloud<PointType>::Ptr Removerter::local2global(const pcl::PointCloud<PointType>::Ptr& _scan_local,
+                                                         int _scan_idx)
 {
-    Eigen::Matrix4d scan_pose = scan_poses_.at(_scan_idx);
+  Eigen::Matrix4d scan_pose = scan_poses_.at(_scan_idx);
 
-    pcl::PointCloud<PointType>::Ptr scan_global(new pcl::PointCloud<PointType>());
-    pcl::transformPointCloud(*_scan_local, *scan_global, kSE3MatExtrinsicLiDARtoPoseBase);
-    pcl::transformPointCloud(*scan_global, *scan_global, scan_pose);
+  pcl::PointCloud<PointType>::Ptr scan_global(new pcl::PointCloud<PointType>());
+  pcl::transformPointCloud(*_scan_local, *scan_global, kSE3MatExtrinsicLiDARtoPoseBase);
+  pcl::transformPointCloud(*scan_global, *scan_global, scan_pose);
 
-    return scan_global;
+  return scan_global;
 }
 
-pcl::PointCloud<PointType>::Ptr Removerter::global2local(const pcl::PointCloud<PointType>::Ptr& _scan_global, int _scan_idx)
+pcl::PointCloud<PointType>::Ptr Removerter::global2local(const pcl::PointCloud<PointType>::Ptr& _scan_global,
+                                                         int _scan_idx)
 {
-    Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_scan_idx);
-    
-    pcl::PointCloud<PointType>::Ptr scan_local(new pcl::PointCloud<PointType>());
-    pcl::transformPointCloud(*_scan_global, *scan_local, base_pose_inverse);
-    pcl::transformPointCloud(*scan_local, *scan_local, kSE3MatExtrinsicPoseBasetoLiDAR);
+  Eigen::Matrix4d base_pose_inverse = scan_inverse_poses_.at(_scan_idx);
 
-    return scan_local;
+  pcl::PointCloud<PointType>::Ptr scan_local(new pcl::PointCloud<PointType>());
+  pcl::transformPointCloud(*_scan_global, *scan_local, base_pose_inverse);
+  pcl::transformPointCloud(*scan_local, *scan_local, kSE3MatExtrinsicPoseBasetoLiDAR);
+
+  return scan_local;
 }
 
-std::pair<pcl::PointCloud<PointType>::Ptr, pcl::PointCloud<PointType>::Ptr> 
-    Removerter::removeDynamicPointsOfScanByKnn ( int _scan_idx )
-{    
-    // curr scan (in local coord)
-    pcl::PointCloud<PointType>::Ptr scan_orig = scans_.at(_scan_idx); 
-    auto scan_pose = scan_poses_.at(_scan_idx);
+std::pair<pcl::PointCloud<PointType>::Ptr, pcl::PointCloud<PointType>::Ptr>
+Removerter::removeDynamicPointsOfScanByKnn(int _scan_idx)
+{
+  // curr scan (in local coord)
+  pcl::PointCloud<PointType>::Ptr scan_orig = scans_.at(_scan_idx);
+  auto scan_pose = scan_poses_.at(_scan_idx);
 
-    // curr scan (in global coord)
-    pcl::PointCloud<PointType>::Ptr scan_orig_global = local2global(scan_orig, _scan_idx);
-    kdtree_scan_global_curr_->setInputCloud(scan_orig_global); 
-    int num_points_of_a_scan = scan_orig_global->points.size();
+  // curr scan (in global coord)
+  pcl::PointCloud<PointType>::Ptr scan_orig_global = local2global(scan_orig, _scan_idx);
+  kdtree_scan_global_curr_->setInputCloud(scan_orig_global);
+  int num_points_of_a_scan = scan_orig_global->points.size();
 
-    // 
-    pcl::PointCloud<PointType>::Ptr scan_static_global (new pcl::PointCloud<PointType>); 
-    pcl::PointCloud<PointType>::Ptr scan_dynamic_global (new pcl::PointCloud<PointType>); 
-    for (std::size_t pt_idx = 0; pt_idx < num_points_of_a_scan; pt_idx++)
+  //
+  pcl::PointCloud<PointType>::Ptr scan_static_global(new pcl::PointCloud<PointType>);
+  pcl::PointCloud<PointType>::Ptr scan_dynamic_global(new pcl::PointCloud<PointType>);
+  for (std::size_t pt_idx = 0; pt_idx < num_points_of_a_scan; pt_idx++)
+  {
+    std::vector<int> topk_indexes_scan;
+    std::vector<float> topk_L2dists_scan;
+    kdtree_scan_global_curr_->nearestKSearch(scan_orig_global->points[pt_idx], kNumKnnPointsToCompare,
+                                             topk_indexes_scan, topk_L2dists_scan);
+    float sum_topknn_dists_in_scan = accumulate(topk_L2dists_scan.begin(), topk_L2dists_scan.end(), 0.0);
+    float avg_topknn_dists_in_scan = sum_topknn_dists_in_scan / float(kNumKnnPointsToCompare);
+
+    std::vector<int> topk_indexes_map;
+    std::vector<float> topk_L2dists_map;
+    kdtree_map_global_curr_->nearestKSearch(scan_orig_global->points[pt_idx], kNumKnnPointsToCompare, topk_indexes_map,
+                                            topk_L2dists_map);
+    float sum_topknn_dists_in_map = accumulate(topk_L2dists_map.begin(), topk_L2dists_map.end(), 0.0);
+    float avg_topknn_dists_in_map = sum_topknn_dists_in_map / float(kNumKnnPointsToCompare);
+
+    //
+    if (std::abs(avg_topknn_dists_in_scan - avg_topknn_dists_in_map) < kScanKnnAndMapKnnAvgDiffThreshold)
     {
-        std::vector<int> topk_indexes_scan;
-        std::vector<float> topk_L2dists_scan;
-        kdtree_scan_global_curr_->nearestKSearch(scan_orig_global->points[pt_idx], kNumKnnPointsToCompare, topk_indexes_scan, topk_L2dists_scan);
-        float sum_topknn_dists_in_scan = accumulate( topk_L2dists_scan.begin(), topk_L2dists_scan.end(), 0.0);
-        float avg_topknn_dists_in_scan = sum_topknn_dists_in_scan / float(kNumKnnPointsToCompare);
-
-        std::vector<int> topk_indexes_map;
-        std::vector<float> topk_L2dists_map;
-        kdtree_map_global_curr_->nearestKSearch(scan_orig_global->points[pt_idx], kNumKnnPointsToCompare, topk_indexes_map, topk_L2dists_map);
-        float sum_topknn_dists_in_map = accumulate( topk_L2dists_map.begin(), topk_L2dists_map.end(), 0.0);
-        float avg_topknn_dists_in_map = sum_topknn_dists_in_map / float(kNumKnnPointsToCompare);
-
-        // 
-        if ( std::abs(avg_topknn_dists_in_scan - avg_topknn_dists_in_map) < kScanKnnAndMapKnnAvgDiffThreshold) {
-            scan_static_global->push_back(scan_orig_global->points[pt_idx]);
-        } else {
-            scan_dynamic_global->push_back(scan_orig_global->points[pt_idx]);
-        }
+      scan_static_global->push_back(scan_orig_global->points[pt_idx]);
     }
+    else
+    {
+      scan_dynamic_global->push_back(scan_orig_global->points[pt_idx]);
+    }
+  }
 
-    // again global2local because later in the merging global map function, which requires scans within each local coord. 
-    pcl::PointCloud<PointType>::Ptr scan_static_local = global2local(scan_static_global, _scan_idx);
-    pcl::PointCloud<PointType>::Ptr scan_dynamic_local = global2local(scan_dynamic_global, _scan_idx);
+  // again global2local because later in the merging global map function, which requires scans within each local coord.
+  pcl::PointCloud<PointType>::Ptr scan_static_local = global2local(scan_static_global, _scan_idx);
+  pcl::PointCloud<PointType>::Ptr scan_dynamic_local = global2local(scan_dynamic_global, _scan_idx);
 
-    ROS_INFO_STREAM("\033[1;32m The scan " << sequence_valid_scan_paths_.at(_scan_idx) << "\033[0m"); 
-    ROS_INFO_STREAM("\033[1;32m -- The number of static points in a scan: " << scan_static_local->points.size() << "\033[0m"); 
-    ROS_INFO_STREAM("\033[1;32m -- The number of dynamic points in a scan: " << num_points_of_a_scan - scan_static_local->points.size() << "\033[0m"); 
+  ROS_INFO_STREAM("\033[1;32m The scan " << sequence_valid_scan_paths_.at(_scan_idx) << "\033[0m");
+  ROS_INFO_STREAM("\033[1;32m -- The number of static points in a scan: " << scan_static_local->points.size()
+                                                                          << "\033[0m");
+  ROS_INFO_STREAM("\033[1;32m -- The number of dynamic points in a scan: "
+                  << num_points_of_a_scan - scan_static_local->points.size() << "\033[0m");
 
-    publishPointcloud2FromPCLptr(static_curr_scan_publisher_, scan_static_local);
-    publishPointcloud2FromPCLptr(dynamic_curr_scan_publisher_, scan_dynamic_local);
-    usleep( kPauseTimeForClearStaticScanVisualization );
+  publishPointcloud2FromPCLptr(static_curr_scan_publisher_, scan_static_local);
+  publishPointcloud2FromPCLptr(dynamic_curr_scan_publisher_, scan_dynamic_local);
+  usleep(kPauseTimeForClearStaticScanVisualization);
 
-    return std::pair<pcl::PointCloud<PointType>::Ptr, pcl::PointCloud<PointType>::Ptr> (scan_static_local, scan_dynamic_local);
+  return std::pair<pcl::PointCloud<PointType>::Ptr, pcl::PointCloud<PointType>::Ptr>(scan_static_local,
+                                                                                     scan_dynamic_local);
 
-} // removeDynamicPointsOfScanByKnn
+}  // removeDynamicPointsOfScanByKnn
 
-
-void Removerter::saveStaticScan( int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud )
+void Removerter::saveStaticScan(int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud)
 {
+  std::string file_name_orig = sequence_valid_scan_names_.at(_scan_idx);
+  std::string file_name = scan_static_save_dir_ + "/" + file_name_orig + ".pcd";
+  ROS_INFO_STREAM("\033[1;32m Scan " << _scan_idx << "'s static points is saved (" << file_name << ")\033[0m");
+  savePCD(file_name, _ptcloud);
+}  // saveStaticScan
 
-    std::string file_name_orig = sequence_valid_scan_names_.at(_scan_idx);
-    std::string file_name = scan_static_save_dir_ + "/" + file_name_orig + ".pcd";
-    ROS_INFO_STREAM("\033[1;32m Scan " << _scan_idx << "'s static points is saved (" << file_name << ")\033[0m");   
-    savePCD(file_name, _ptcloud);
-} // saveStaticScan
-
-
-void Removerter::saveDynamicScan( int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud )
+void Removerter::saveDynamicScan(int _scan_idx, const pcl::PointCloud<PointType>::Ptr& _ptcloud)
 {
-    std::string file_name_orig = sequence_valid_scan_names_.at(_scan_idx);
-    std::string file_name = scan_dynamic_save_dir_ + "/" + file_name_orig + ".pcd";
-    ROS_INFO_STREAM("\033[1;32m Scan " << _scan_idx << "'s static points is saved (" << file_name << ")\033[0m");   
-    savePCD(file_name, _ptcloud);
-} // saveDynamicScan
-
+  std::string file_name_orig = sequence_valid_scan_names_.at(_scan_idx);
+  std::string file_name = scan_dynamic_save_dir_ + "/" + file_name_orig + ".pcd";
+  ROS_INFO_STREAM("\033[1;32m Scan " << _scan_idx << "'s static points is saved (" << file_name << ")\033[0m");
+  savePCD(file_name, _ptcloud);
+}  // saveDynamicScan
 
 void Removerter::saveCleanedScans(void)
 {
-    if( ! kFlagSaveCleanScans )
-        return;
+  if (!kFlagSaveCleanScans)
+    return;
 
-    for(std::size_t idx_scan=0; idx_scan < scans_static_.size(); idx_scan++) {  
-        saveStaticScan(idx_scan, scans_static_.at(idx_scan));
-        saveDynamicScan(idx_scan, scans_dynamic_.at(idx_scan));
-    }
-} // saveCleanedScans
-
+  for (std::size_t idx_scan = 0; idx_scan < scans_static_.size(); idx_scan++)
+  {
+    saveStaticScan(idx_scan, scans_static_.at(idx_scan));
+    saveDynamicScan(idx_scan, scans_dynamic_.at(idx_scan));
+  }
+}  // saveCleanedScans
 
 void Removerter::saveMapPointcloudByMergingCleanedScans(void)
 {
-    // merge for verification
-    if( ! kFlagSaveMapPointcloud ) 
-        return;
+  // merge for verification
+  if (!kFlagSaveMapPointcloud)
+    return;
 
-    // static map
-    {
-        pcl::PointCloud<PointType>::Ptr map_global_static_scans_merged_to_verify_full (new pcl::PointCloud<PointType>); 
-        pcl::PointCloud<PointType>::Ptr map_global_static_scans_merged_to_verify (new pcl::PointCloud<PointType>); 
-        mergeScansWithinGlobalCoord(scans_static_, scan_poses_, map_global_static_scans_merged_to_verify_full);
-        Downsampling(map_global_static_scans_merged_to_verify_full, map_global_static_scans_merged_to_verify);
+  // static map
+  {
+    pcl::PointCloud<PointType>::Ptr map_global_static_scans_merged_to_verify_full(new pcl::PointCloud<PointType>);
+    pcl::PointCloud<PointType>::Ptr map_global_static_scans_merged_to_verify(new pcl::PointCloud<PointType>);
+    mergeScansWithinGlobalCoord(scans_static_, scan_poses_, map_global_static_scans_merged_to_verify_full);
+    Downsampling(map_global_static_scans_merged_to_verify_full, map_global_static_scans_merged_to_verify);
 
-        // global
-        std::string local_file_name = map_static_save_dir_ + "/StaticMapScansideMapGlobal.pcd";
-        savePCD(local_file_name, map_global_static_scans_merged_to_verify);
-        ROS_INFO_STREAM("\033[1;32m  [For verification] A static pointcloud (cleaned scans merged) is saved (global coord): " << local_file_name << "\033[0m");   
+    // global
+    std::string local_file_name = map_static_save_dir_ + "/StaticMapScansideMapGlobal.pcd";
+    savePCD(local_file_name, map_global_static_scans_merged_to_verify);
+    ROS_INFO_STREAM(
+        "\033[1;32m  [For verification] A static pointcloud (cleaned scans merged) is saved (global coord): "
+        << local_file_name << "\033[0m");
 
-        // local 
-        pcl::PointCloud<PointType>::Ptr map_local_static_scans_merged_to_verify (new pcl::PointCloud<PointType>);
-        int base_node_idx = base_node_idx_;
-        transformGlobalMapToLocal(map_global_static_scans_merged_to_verify, base_node_idx, map_local_static_scans_merged_to_verify);
-        std::string global_file_name = map_static_save_dir_ + "/StaticMapScansideMapLocal.pcd";
-        savePCD(global_file_name, map_local_static_scans_merged_to_verify);
-        ROS_INFO_STREAM("\033[1;32m  [For verification] A static pointcloud (cleaned scans merged) is saved (local coord): " << global_file_name << "\033[0m");  
-    } 
+    // local
+    pcl::PointCloud<PointType>::Ptr map_local_static_scans_merged_to_verify(new pcl::PointCloud<PointType>);
+    int base_node_idx = base_node_idx_;
+    transformGlobalMapToLocal(map_global_static_scans_merged_to_verify, base_node_idx,
+                              map_local_static_scans_merged_to_verify);
+    std::string global_file_name = map_static_save_dir_ + "/StaticMapScansideMapLocal.pcd";
+    savePCD(global_file_name, map_local_static_scans_merged_to_verify);
+    ROS_INFO_STREAM("\033[1;32m  [For verification] A static pointcloud (cleaned scans merged) is saved (local coord): "
+                    << global_file_name << "\033[0m");
+  }
 
-    // dynamic map
-    {
-        pcl::PointCloud<PointType>::Ptr map_global_dynamic_scans_merged_to_verify_full (new pcl::PointCloud<PointType>); 
-        pcl::PointCloud<PointType>::Ptr map_global_dynamic_scans_merged_to_verify (new pcl::PointCloud<PointType>); 
-        mergeScansWithinGlobalCoord(scans_dynamic_, scan_poses_, map_global_dynamic_scans_merged_to_verify_full);
-        Downsampling(map_global_dynamic_scans_merged_to_verify_full, map_global_dynamic_scans_merged_to_verify);
+  // dynamic map
+  {
+    pcl::PointCloud<PointType>::Ptr map_global_dynamic_scans_merged_to_verify_full(new pcl::PointCloud<PointType>);
+    pcl::PointCloud<PointType>::Ptr map_global_dynamic_scans_merged_to_verify(new pcl::PointCloud<PointType>);
+    mergeScansWithinGlobalCoord(scans_dynamic_, scan_poses_, map_global_dynamic_scans_merged_to_verify_full);
+    Downsampling(map_global_dynamic_scans_merged_to_verify_full, map_global_dynamic_scans_merged_to_verify);
 
-        // global
-        std::string local_file_name = map_dynamic_save_dir_ + "/DynamicMapScansideMapGlobal.pcd";
-        savePCD(local_file_name, map_global_dynamic_scans_merged_to_verify);
-        ROS_INFO_STREAM("\033[1;32m  [For verification] A dynamic pointcloud (cleaned scans merged) is saved (global coord): " << local_file_name << "\033[0m");   
+    // global
+    std::string local_file_name = map_dynamic_save_dir_ + "/DynamicMapScansideMapGlobal.pcd";
+    savePCD(local_file_name, map_global_dynamic_scans_merged_to_verify);
+    ROS_INFO_STREAM(
+        "\033[1;32m  [For verification] A dynamic pointcloud (cleaned scans merged) is saved (global coord): "
+        << local_file_name << "\033[0m");
 
-        // local 
-        pcl::PointCloud<PointType>::Ptr map_local_dynamic_scans_merged_to_verify (new pcl::PointCloud<PointType>);
-        int base_node_idx = base_node_idx_;
-        transformGlobalMapToLocal(map_global_dynamic_scans_merged_to_verify, base_node_idx, map_local_dynamic_scans_merged_to_verify);
-        std::string global_file_name = map_dynamic_save_dir_ + "/DynamicMapScansideMapLocal.pcd";
-        savePCD(global_file_name, map_local_dynamic_scans_merged_to_verify);
-        ROS_INFO_STREAM("\033[1;32m  [For verification] A dynamic pointcloud (cleaned scans merged) is saved (local coord): " << global_file_name << "\033[0m");  
-    } 
-} // saveMapPointcloudByMergingCleanedScans
+    // local
+    pcl::PointCloud<PointType>::Ptr map_local_dynamic_scans_merged_to_verify(new pcl::PointCloud<PointType>);
+    int base_node_idx = base_node_idx_;
+    transformGlobalMapToLocal(map_global_dynamic_scans_merged_to_verify, base_node_idx,
+                              map_local_dynamic_scans_merged_to_verify);
+    std::string global_file_name = map_dynamic_save_dir_ + "/DynamicMapScansideMapLocal.pcd";
+    savePCD(global_file_name, map_local_dynamic_scans_merged_to_verify);
+    ROS_INFO_STREAM(
+        "\033[1;32m  [For verification] A dynamic pointcloud (cleaned scans merged) is saved (local coord): "
+        << global_file_name << "\033[0m");
+  }
+}  // saveMapPointcloudByMergingCleanedScans
 
-
-void Removerter::scansideRemovalForEachScan( void )
+void Removerter::scansideRemovalForEachScan(void)
 {
-    // for fast scan-side neighbor search 
-    kdtree_map_global_curr_->setInputCloud(map_global_curr_); 
+  // for fast scan-side neighbor search
+  kdtree_map_global_curr_->setInputCloud(map_global_curr_);
 
-    // for each scan
-    for(std::size_t idx_scan=0; idx_scan < scans_.size(); idx_scan++) {
-        auto [this_scan_static, this_scan_dynamic] = removeDynamicPointsOfScanByKnn(idx_scan);
-        scans_static_.emplace_back(this_scan_static);
-        scans_dynamic_.emplace_back(this_scan_dynamic);
-    }
-} // scansideRemovalForEachScan
+  // for each scan
+  for (std::size_t idx_scan = 0; idx_scan < scans_.size(); idx_scan++)
+  {
+    auto [this_scan_static, this_scan_dynamic] = removeDynamicPointsOfScanByKnn(idx_scan);
+    scans_static_.emplace_back(this_scan_static);
+    scans_dynamic_.emplace_back(this_scan_dynamic);
+  }
+}  // scansideRemovalForEachScan
 
-
-void Removerter::scansideRemovalForEachScanAndSaveThem( void )
+void Removerter::scansideRemovalForEachScanAndSaveThem(void)
 {
-    scansideRemovalForEachScan();
-    saveCleanedScans();
-    saveMapPointcloudByMergingCleanedScans();
-} // scansideRemovalForEachScanAndSaveThem
+  scansideRemovalForEachScan();
+  saveCleanedScans();
+  saveMapPointcloudByMergingCleanedScans();
+}  // scansideRemovalForEachScanAndSaveThem
 
-
-void Removerter::run( void )
+void Removerter::run(void)
 {
-    // load scan and poses
-    parseValidScanInfo();
-    readValidScans();
+  // load scan and poses
+  parseValidScanInfo();
+  readValidScans();
 
-    // construct initial map using the scans and the corresponding poses 
-    makeGlobalMap();
+  // construct initial map using the scans and the corresponding poses
+  makeGlobalMap();
 
-    // map-side removals
-    for(float _rm_res: remove_resolution_list_) {
-        removeOnce( _rm_res );
-    } 
+  // map-side removals
+  for (float _rm_res : remove_resolution_list_)
+  {
+    removeOnce(_rm_res);
+  }
 
-    // if you want to every iteration's map data, place below two lines to inside of the above for loop 
-    saveCurrentStaticAndDynamicPointCloudGlobal(); // if you want to save within the global points uncomment this line
-    saveCurrentStaticAndDynamicPointCloudLocal(base_node_idx_); // w.r.t specific node's coord. 0 means w.r.t the start node, as an Identity.
+  // if you want to every iteration's map data, place below two lines to inside of the above for loop
+  saveCurrentStaticAndDynamicPointCloudGlobal();  // if you want to save within the global points uncomment this line
+  saveCurrentStaticAndDynamicPointCloudLocal(base_node_idx_);  // w.r.t specific node's coord. 0 means w.r.t the start
+                                                               // node, as an Identity.
 
-    // TODO
-    // map-side reverts
-    // if you want to remove as much as possible, you can use omit this steps
-    for(float _rv_res: revert_resolution_list_) {
-        revertOnce( _rv_res );
-    }
+  // TODO
+  // map-side reverts
+  // if you want to remove as much as possible, you can use omit this steps
+  for (float _rv_res : revert_resolution_list_)
+  {
+    revertOnce(_rv_res);
+  }
 
-    // scan-side removals
-    scansideRemovalForEachScanAndSaveThem();
-
+  // scan-side removals
+  scansideRemovalForEachScanAndSaveThem();
 }

--- a/src/Removerter.cpp
+++ b/src/Removerter.cpp
@@ -100,7 +100,7 @@ void Removerter::parseValidScanInfo(void)
   for (int curr_idx = 0; curr_idx < int(sequence_scan_paths_.size()); curr_idx++)
   {
     // check the scan idx within the target idx range
-    if (curr_idx > end_idx_ || curr_idx < start_idx_)
+    if (!clean_for_all_scan_ && (curr_idx > end_idx_ || curr_idx < start_idx_))
     {
       curr_idx++;
       continue;

--- a/src/RosParamServer.cpp
+++ b/src/RosParamServer.cpp
@@ -91,6 +91,12 @@ RosParamServer::RosParamServer() : nh(nh_super), ROSimg_transporter_(nh)
   nh.param<int>("removert/keyframe_gap", keyframe_gap_, 10);
   nh.param<float>("removert/keyframe_meter", keyframe_gap_meter_, 2.0);
 
+  // scan-side removals
+  nh.param<bool>("removert/scan_side_removals", scan_side_removals_, true);
+  nh.param<int>("removert/num_nn_points_within", kNumKnnPointsToCompare, 3);  // using higher, more strict static
+  nh.param<float>("removert/dist_nn_points_within", kScanKnnAndMapKnnAvgDiffThreshold,
+                  0.1);  // using smaller, more strict static
+
   // faster
   nh.param<int>("removert/num_omp_cores", kNumOmpCores, 4);
 

--- a/src/RosParamServer.cpp
+++ b/src/RosParamServer.cpp
@@ -84,6 +84,7 @@ RosParamServer::RosParamServer() : nh(nh_super), ROSimg_transporter_(nh)
   // target scan index range (used in Removert.cpp)
   nh.param<int>("removert/start_idx", start_idx_, 1);
   nh.param<int>("removert/end_idx", end_idx_, 100);
+  nh.param<bool>("removert/clean_for_all_scan", clean_for_all_scan_, false);
 
   nh.param<bool>("removert/use_keyframe_gap", use_keyframe_gap_, true);
   nh.param<bool>("removert/use_keyframe_meter", use_keyframe_meter_, false);

--- a/src/RosParamServer.cpp
+++ b/src/RosParamServer.cpp
@@ -1,104 +1,105 @@
 #include "removert/RosParamServer.h"
 
-
-RosParamServer::RosParamServer()
-: nh(nh_super), ROSimg_transporter_(nh)
+RosParamServer::RosParamServer() : nh(nh_super), ROSimg_transporter_(nh)
 {
-    nh.param<bool>("removert/isScanFileKITTIFormat", isScanFileKITTIFormat_, true);
+  nh.param<bool>("removert/isScanFileKITTIFormat", isScanFileKITTIFormat_, true);
 
-    // for visualization 
- 
-    scan_rimg_msg_publisher_ = ROSimg_transporter_.advertise("/scan_rimg_single", 10);
-    map_rimg_msg_publisher_ = ROSimg_transporter_.advertise("/map_rimg_single", 10);
-    diff_rimg_msg_publisher_ = ROSimg_transporter_.advertise("/diff_rimg_single", 10);
-    map_rimg_ptidx_msg_publisher_ = ROSimg_transporter_.advertise("/map_rimg_ptidx_single", 10);
+  // for visualization
 
-    nh.param<float>("removert/rimg_color_min", rimg_color_min_, 0.0);
-    nh.param<float>("removert/rimg_color_max", rimg_color_max_, 10.0);
-    kRangeColorAxis = std::pair<float, float> {rimg_color_min_, rimg_color_max_}; // meter
-    kRangeColorAxisForDiff = std::pair<float, float>{0.0, 0.5}; // meter 
+  scan_rimg_msg_publisher_ = ROSimg_transporter_.advertise("/scan_rimg_single", 10);
+  map_rimg_msg_publisher_ = ROSimg_transporter_.advertise("/map_rimg_single", 10);
+  diff_rimg_msg_publisher_ = ROSimg_transporter_.advertise("/diff_rimg_single", 10);
+  map_rimg_ptidx_msg_publisher_ = ROSimg_transporter_.advertise("/map_rimg_ptidx_single", 10);
 
-    // fov 
-    nh.param<float>("removert/sequence_vfov", kVFOV, 50.0);
-    nh.param<float>("removert/sequence_hfov", kHFOV, 360.0);
-    kFOV = std::pair<float, float>(kVFOV, kHFOV);
+  nh.param<float>("removert/rimg_color_min", rimg_color_min_, 0.0);
+  nh.param<float>("removert/rimg_color_max", rimg_color_max_, 10.0);
+  kRangeColorAxis = std::pair<float, float>{ rimg_color_min_, rimg_color_max_ };  // meter
+  kRangeColorAxisForDiff = std::pair<float, float>{ 0.0, 0.5 };                   // meter
 
-    // resolution 
-    nh.param<std::vector<float>>("removert/remove_resolution_list", remove_resolution_list_, std::vector<float>());
-    nh.param<std::vector<float>>("removert/revert_resolution_list", revert_resolution_list_, std::vector<float>());
+  // fov
+  nh.param<float>("removert/sequence_vfov", kVFOV, 50.0);
+  nh.param<float>("removert/sequence_hfov", kHFOV, 360.0);
+  kFOV = std::pair<float, float>(kVFOV, kHFOV);
 
-    // sequcne system info 
-    nh.param<std::vector<double>>("removert/ExtrinsicLiDARtoPoseBase", kVecExtrinsicLiDARtoPoseBase, std::vector<double>());
-    kSE3MatExtrinsicLiDARtoPoseBase = Eigen::Map<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>>(kVecExtrinsicLiDARtoPoseBase.data(), 4, 4);
-    kSE3MatExtrinsicPoseBasetoLiDAR = kSE3MatExtrinsicLiDARtoPoseBase.inverse();
+  // resolution
+  nh.param<std::vector<float>>("removert/remove_resolution_list", remove_resolution_list_, std::vector<float>());
+  nh.param<std::vector<float>>("removert/revert_resolution_list", revert_resolution_list_, std::vector<float>());
 
-    // parsing bin file paths 
-    nh.param<std::string>("removert/sequence_scan_dir", sequence_scan_dir_, "/use/your/directory/having/*.bin");
-    for(auto& _entry : fs::directory_iterator(sequence_scan_dir_)) {
-        sequence_scan_names_.emplace_back(_entry.path().filename());
-        sequence_scan_paths_.emplace_back(_entry.path());
-    }
-    std::sort(sequence_scan_names_.begin(), sequence_scan_names_.end());
-    std::sort(sequence_scan_paths_.begin(), sequence_scan_paths_.end());
+  // sequcne system info
+  nh.param<std::vector<double>>("removert/ExtrinsicLiDARtoPoseBase", kVecExtrinsicLiDARtoPoseBase,
+                                std::vector<double>());
+  kSE3MatExtrinsicLiDARtoPoseBase =
+      Eigen::Map<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>>(kVecExtrinsicLiDARtoPoseBase.data(), 4, 4);
+  kSE3MatExtrinsicPoseBasetoLiDAR = kSE3MatExtrinsicLiDARtoPoseBase.inverse();
 
-    num_total_scans_of_sequence_ = sequence_scan_paths_.size();
-    ROS_INFO_STREAM("\033[1;32m Total : " << num_total_scans_of_sequence_ << " scans in the directory.\033[0m");
+  // parsing bin file paths
+  nh.param<std::string>("removert/sequence_scan_dir", sequence_scan_dir_, "/use/your/directory/having/*.bin");
+  for (auto& _entry : fs::directory_iterator(sequence_scan_dir_))
+  {
+    sequence_scan_names_.emplace_back(_entry.path().filename());
+    sequence_scan_paths_.emplace_back(_entry.path());
+  }
+  std::sort(sequence_scan_names_.begin(), sequence_scan_names_.end());
+  std::sort(sequence_scan_paths_.begin(), sequence_scan_paths_.end());
 
-    // point cloud pre-processing
-    nh.param<float>("removert/downsample_voxel_size", kDownsampleVoxelSize, 0.05);
+  num_total_scans_of_sequence_ = sequence_scan_paths_.size();
+  ROS_INFO_STREAM("\033[1;32m Total : " << num_total_scans_of_sequence_ << " scans in the directory.\033[0m");
 
-    // parsing pose info
-    nh.param<std::string>("removert/sequence_pose_path", sequence_pose_path_, "/use/your/path/having/pose.txt");
-    std::ifstream pose_file_handle (sequence_pose_path_);
-    int num_poses {0};
-    std::string strOneLine;
-    while (getline(pose_file_handle, strOneLine)) 
+  // point cloud pre-processing
+  nh.param<float>("removert/downsample_voxel_size", kDownsampleVoxelSize, 0.05);
+
+  // parsing pose info
+  nh.param<std::string>("removert/sequence_pose_path", sequence_pose_path_, "/use/your/path/having/pose.txt");
+  std::ifstream pose_file_handle(sequence_pose_path_);
+  int num_poses{ 0 };
+  std::string strOneLine;
+  while (getline(pose_file_handle, strOneLine))
+  {
+    // str to vec
+    std::vector<double> ith_pose_vec = splitPoseLine(strOneLine, ' ');
+    if (ith_pose_vec.size() == 12)
     {
-        // str to vec
-        std::vector<double> ith_pose_vec = splitPoseLine(strOneLine, ' ');
-        if(ith_pose_vec.size() == 12) {
-            ith_pose_vec.emplace_back(double(0.0)); 
-            ith_pose_vec.emplace_back(double(0.0)); 
-            ith_pose_vec.emplace_back(double(0.0)); 
-            ith_pose_vec.emplace_back(double(1.0));
-        }
-    
-        // vec to eig
-        Eigen::Matrix4d ith_pose = Eigen::Map<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>>(ith_pose_vec.data(), 4, 4);
-        Eigen::Matrix4d ith_pose_inverse = ith_pose.inverse();
-
-        // save (move)
-        // cout << "Pose of scan: " << sequence_scan_names_.at(num_poses) << endl;
-        // cout << ith_pose << endl;
-        sequence_scan_poses_.emplace_back(ith_pose);
-        sequence_scan_inverse_poses_.emplace_back(ith_pose_inverse);
-
-        num_poses++;
+      ith_pose_vec.emplace_back(double(0.0));
+      ith_pose_vec.emplace_back(double(0.0));
+      ith_pose_vec.emplace_back(double(0.0));
+      ith_pose_vec.emplace_back(double(1.0));
     }
-    // check the number of scans and the number of poses are equivalent
-    assert(sequence_scan_paths_.size() == sequence_scan_poses_.size());
 
-    // target scan index range (used in Removert.cpp)
-    nh.param<int>("removert/start_idx", start_idx_, 1);
-    nh.param<int>("removert/end_idx", end_idx_, 100);
+    // vec to eig
+    Eigen::Matrix4d ith_pose =
+        Eigen::Map<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>>(ith_pose_vec.data(), 4, 4);
+    Eigen::Matrix4d ith_pose_inverse = ith_pose.inverse();
 
-    nh.param<bool>("removert/use_keyframe_gap", use_keyframe_gap_, true);
-    nh.param<bool>("removert/use_keyframe_meter", use_keyframe_meter_, false);
-    nh.param<int>("removert/keyframe_gap", keyframe_gap_, 10);
-    nh.param<float>("removert/keyframe_meter", keyframe_gap_meter_, 2.0);
+    // save (move)
+    // cout << "Pose of scan: " << sequence_scan_names_.at(num_poses) << endl;
+    // cout << ith_pose << endl;
+    sequence_scan_poses_.emplace_back(ith_pose);
+    sequence_scan_inverse_poses_.emplace_back(ith_pose_inverse);
 
-    // faster
-    nh.param<int>("removert/num_omp_cores", kNumOmpCores, 4);
+    num_poses++;
+  }
+  // check the number of scans and the number of poses are equivalent
+  assert(sequence_scan_paths_.size() == sequence_scan_poses_.size());
 
-    // save info
-    nh.param<bool>("removert/saveMapPCD", kFlagSaveMapPointcloud, false);
-    nh.param<bool>("removert/saveCleanScansPCD", kFlagSaveCleanScans, false);
-    nh.param<std::string>("removert/save_pcd_directory", save_pcd_directory_, "/");
+  // target scan index range (used in Removert.cpp)
+  nh.param<int>("removert/start_idx", start_idx_, 1);
+  nh.param<int>("removert/end_idx", end_idx_, 100);
 
-    // colorize
-    nh.param<bool>("removert/use_rgb", use_rgb, false);
+  nh.param<bool>("removert/use_keyframe_gap", use_keyframe_gap_, true);
+  nh.param<bool>("removert/use_keyframe_meter", use_keyframe_meter_, false);
+  nh.param<int>("removert/keyframe_gap", keyframe_gap_, 10);
+  nh.param<float>("removert/keyframe_meter", keyframe_gap_meter_, 2.0);
 
+  // faster
+  nh.param<int>("removert/num_omp_cores", kNumOmpCores, 4);
 
-    usleep(100);
-} // ctor RosParamServer
+  // save info
+  nh.param<bool>("removert/saveMapPCD", kFlagSaveMapPointcloud, false);
+  nh.param<bool>("removert/saveCleanScansPCD", kFlagSaveCleanScans, false);
+  nh.param<std::string>("removert/save_pcd_directory", save_pcd_directory_, "/");
 
+  // colorize
+  nh.param<bool>("removert/use_rgb", use_rgb, false);
+
+  usleep(100);
+}  // ctor RosParamServer

--- a/src/removert_main.cpp
+++ b/src/removert_main.cpp
@@ -2,13 +2,13 @@
 
 int main(int argc, char** argv)
 {
-    ros::init(argc, argv, "removert");
-    ROS_INFO("\033[1;32m----> Removert Main Started.\033[0m");
+  ros::init(argc, argv, "removert");
+  ROS_INFO("\033[1;32m----> Removert Main Started.\033[0m");
 
-    Removerter RMV;
-    RMV.run();
+  Removerter RMV;
+  RMV.run();
 
-    ros::spin();
+  ros::spin();
 
-    return 0;
+  return 0;
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -2,127 +2,122 @@
 
 bool cout_debug = false;
 
-
 void readBin(std::string _bin_path, pcl::PointCloud<PointType>::Ptr _pcd_ptr)
 {
- 	std::fstream input(_bin_path.c_str(), ios::in | ios::binary);
-	if(!input.good()){
-		cerr << "Could not read file: " << _bin_path << endl;
-		exit(EXIT_FAILURE);
-	}
-	input.seekg(0, ios::beg);
-  
-	for (int ii=0; input.good() && !input.eof(); ii++) {
-		PointType point;
+  std::fstream input(_bin_path.c_str(), ios::in | ios::binary);
+  if (!input.good())
+  {
+    cerr << "Could not read file: " << _bin_path << endl;
+    exit(EXIT_FAILURE);
+  }
+  input.seekg(0, ios::beg);
 
-		input.read((char *) &point.x, sizeof(float));
-		input.read((char *) &point.y, sizeof(float));
-		input.read((char *) &point.z, sizeof(float));
-		input.read((char *) &point.intensity, sizeof(float));
+  for (int ii = 0; input.good() && !input.eof(); ii++)
+  {
+    PointType point;
 
-		_pcd_ptr->push_back(point);
-	}
-	input.close();
+    input.read((char*)&point.x, sizeof(float));
+    input.read((char*)&point.y, sizeof(float));
+    input.read((char*)&point.z, sizeof(float));
+    input.read((char*)&point.intensity, sizeof(float));
+
+    _pcd_ptr->push_back(point);
+  }
+  input.close();
 }
 
-std::vector<double> splitPoseLine(std::string _str_line, char _delimiter) {
-    std::vector<double> parsed;
-    std::stringstream ss(_str_line);
-    std::string temp;
-    while (getline(ss, temp, _delimiter)) {
-        parsed.push_back(std::stod(temp)); // convert string to "double"
-    }
-    return parsed;
+std::vector<double> splitPoseLine(std::string _str_line, char _delimiter)
+{
+  std::vector<double> parsed;
+  std::stringstream ss(_str_line);
+  std::string temp;
+  while (getline(ss, temp, _delimiter))
+  {
+    parsed.push_back(std::stod(temp));  // convert string to "double"
+  }
+  return parsed;
 }
 
-SphericalPoint cart2sph(const PointType & _cp)
-{ // _cp means cartesian point
+SphericalPoint cart2sph(const PointType& _cp)
+{  // _cp means cartesian point
 
-    if(cout_debug){
-        cout << "Cartesian Point [x, y, z]: [" << _cp.x << ", " << _cp.y << ", " << _cp.z << endl;
-    }
+  if (cout_debug)
+  {
+    cout << "Cartesian Point [x, y, z]: [" << _cp.x << ", " << _cp.y << ", " << _cp.z << endl;
+  }
 
-    SphericalPoint sph_point {
-         std::atan2(_cp.y, _cp.x), 
-         std::atan2(_cp.z, std::sqrt(_cp.x*_cp.x + _cp.y*_cp.y)),
-         std::sqrt(_cp.x*_cp.x + _cp.y*_cp.y + _cp.z*_cp.z)
-    };    
-    return sph_point;
+  SphericalPoint sph_point{ std::atan2(_cp.y, _cp.x), std::atan2(_cp.z, std::sqrt(_cp.x * _cp.x + _cp.y * _cp.y)),
+                            std::sqrt(_cp.x * _cp.x + _cp.y * _cp.y + _cp.z * _cp.z) };
+  return sph_point;
 }
-
 
 std::pair<int, int> resetRimgSize(const std::pair<float, float> _fov, const float _resize_ratio)
 {
-    // default is 1 deg x 1 deg 
-    float alpha_vfov = _resize_ratio;    
-    float alpha_hfov = _resize_ratio;    
+  // default is 1 deg x 1 deg
+  float alpha_vfov = _resize_ratio;
+  float alpha_hfov = _resize_ratio;
 
-    float V_FOV = _fov.first;
-    float H_FOV = _fov.second;
+  float V_FOV = _fov.first;
+  float H_FOV = _fov.second;
 
-    int NUM_RANGE_IMG_ROW = std::round(V_FOV*alpha_vfov);
-    int NUM_RANGE_IMG_COL = std::round(H_FOV*alpha_hfov);
+  int NUM_RANGE_IMG_ROW = std::round(V_FOV * alpha_vfov);
+  int NUM_RANGE_IMG_COL = std::round(H_FOV * alpha_hfov);
 
-    std::pair<int, int> rimg {NUM_RANGE_IMG_ROW, NUM_RANGE_IMG_COL};
-    return rimg;
+  std::pair<int, int> rimg{ NUM_RANGE_IMG_ROW, NUM_RANGE_IMG_COL };
+  return rimg;
 }
 
-
-std::set<int> convertIntVecToSet(const std::vector<int> & v) 
-{ 
-    std::set<int> s; 
-    for (int x : v) { 
-        s.insert(x); 
-    } 
-    return s; 
-} 
-
-void pubRangeImg(cv::Mat& _rimg, 
-                sensor_msgs::ImagePtr& _msg,
-                image_transport::Publisher& _publiser,
-                std::pair<float, float> _caxis)
+std::set<int> convertIntVecToSet(const std::vector<int>& v)
 {
-    cv::Mat scan_rimg_viz = convertColorMappedImg(_rimg, _caxis);
-    _msg = cvmat2msg(scan_rimg_viz);
-    _publiser.publish(_msg);    
-} // pubRangeImg
+  std::set<int> s;
+  for (int x : v)
+  {
+    s.insert(x);
+  }
+  return s;
+}
 
+void pubRangeImg(cv::Mat& _rimg, sensor_msgs::ImagePtr& _msg, image_transport::Publisher& _publiser,
+                 std::pair<float, float> _caxis)
+{
+  cv::Mat scan_rimg_viz = convertColorMappedImg(_rimg, _caxis);
+  _msg = cvmat2msg(scan_rimg_viz);
+  _publiser.publish(_msg);
+}  // pubRangeImg
 
-sensor_msgs::ImagePtr cvmat2msg(const cv::Mat &_img)
+sensor_msgs::ImagePtr cvmat2msg(const cv::Mat& _img)
 {
   sensor_msgs::ImagePtr msg = cv_bridge::CvImage(std_msgs::Header(), "bgr8", _img).toImageMsg();
   return msg;
 }
 
-
 void publishPointcloud2FromPCLptr(const ros::Publisher& _scan_publisher, const pcl::PointCloud<PointType>::Ptr _scan)
 {
-    sensor_msgs::PointCloud2 tempCloud;
-    pcl::toROSMsg(*_scan, tempCloud);
-    tempCloud.header.stamp = ros::Time::now();
-    tempCloud.header.frame_id = "removert";
-    _scan_publisher.publish(tempCloud);
-} // publishPointcloud2FromPCLptr
+  sensor_msgs::PointCloud2 tempCloud;
+  pcl::toROSMsg(*_scan, tempCloud);
+  tempCloud.header.stamp = ros::Time::now();
+  tempCloud.header.frame_id = "removert";
+  _scan_publisher.publish(tempCloud);
+}  // publishPointcloud2FromPCLptr
 
-
-sensor_msgs::PointCloud2 publishCloud(ros::Publisher *thisPub, pcl::PointCloud<PointType>::Ptr thisCloud, ros::Time thisStamp, std::string thisFrame)
+sensor_msgs::PointCloud2 publishCloud(ros::Publisher* thisPub, pcl::PointCloud<PointType>::Ptr thisCloud,
+                                      ros::Time thisStamp, std::string thisFrame)
 {
-    sensor_msgs::PointCloud2 tempCloud;
-    pcl::toROSMsg(*thisCloud, tempCloud);
-    tempCloud.header.stamp = thisStamp;
-    tempCloud.header.frame_id = thisFrame;
-    if (thisPub->getNumSubscribers() != 0)
-        thisPub->publish(tempCloud);
-    return tempCloud;
+  sensor_msgs::PointCloud2 tempCloud;
+  pcl::toROSMsg(*thisCloud, tempCloud);
+  tempCloud.header.stamp = thisStamp;
+  tempCloud.header.frame_id = thisFrame;
+  if (thisPub->getNumSubscribers() != 0)
+    thisPub->publish(tempCloud);
+  return tempCloud;
 }
 
 float pointDistance(PointType p)
 {
-    return sqrt(p.x*p.x + p.y*p.y + p.z*p.z);
+  return sqrt(p.x * p.x + p.y * p.y + p.z * p.z);
 }
 
 float pointDistance(PointType p1, PointType p2)
 {
-    return sqrt((p1.x-p2.x)*(p1.x-p2.x) + (p1.y-p2.y)*(p1.y-p2.y) + (p1.z-p2.z)*(p1.z-p2.z));
+  return sqrt((p1.x - p2.x) * (p1.x - p2.x) + (p1.y - p2.y) * (p1.y - p2.y) + (p1.z - p2.z) * (p1.z - p2.z));
 }
-


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
- `removert/clean_for_all_scan`パラメータの機能実装
- scan-side removals機能の利用可否に関わるパラメータの追加
- revert機能の実装

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #3 
- fix #4 

<!-- 変更の詳細 -->
## Detail
### `removert/clean_for_all_scan`パラメータの機能実装 4a0ccdcaf61895537d98e266b6d7319aecbedc84
yamlファイルで`removert/clean_for_all_scan`パラメータが存在していますが、このパラメータの機能が実装されていませんでした。
https://github.com/sbgisen/removert/blob/807d96f095b96e042cf0e17e267074d4f98b197a/config/params_mulran_scliosam.yaml#L49
これまでは`removert/start_idx`と`removert/end_idx`で、removertが利用するPCDファイルのインデックス番号を指定する必要がありましたが`removert/clean_for_all_scan`をtrueにすることで全てのファイルを読み込むことができるように変更を行いました。

### 静的な環境地図を構築するのに不要な処理を省略して実行時間を短縮したい 3cfec17cd35aba380c06e8019797c74e3e123b53
scan-side removalsという機能は、remove -> revertで得られた静的な環境地図を利用して、scan内の動的なオブジェクトを取得、解析することを目的とした機能なため、静的な環境地図を構築するのには不要な処理となります。
https://github.com/sbgisen/removert/blob/807d96f095b96e042cf0e17e267074d4f98b197a/src/Removerter.cpp#L924-L925
そこで、`removert/scan_side_removals`というパラメータを作り、この機能を利用するか否かを変更できるようにすることでremovertの実行時間の短縮を行いました。

### revert機能の実装 7e1333be818504c1e8d57a44b392f245e1440fa2
removertは、大きく分けて`remove`と`revert`の処理が行われるようですが、`revert`にあたる処理が実装されていませんでした。
https://github.com/sbgisen/removert/blob/807d96f095b96e042cf0e17e267074d4f98b197a/src/Removerter.cpp#L920-L922
https://github.com/sbgisen/removert/blob/807d96f095b96e042cf0e17e267074d4f98b197a/src/Removerter.cpp#L691-L701
そこで、論文の内容と[lt-mapper](https://github.com/gisbi-kim/lt-mapper)におけるltremovertの内容を参考にしつつ以下の処理の流れとなるように実装しました。

`Map` : 全てのキーフレームを含む点群(環境地図)
`Dynamic points(rm n)` : removeのn回目の試行における動的な点群
`Static points(rm n)` : removeのn回目の試行における静的な点群
`Dynamic points(rv n)` : revertのn回目の試行における動的な点群
`Static points(rv n)` : revertのn回目の試行における静的な点群

**1. remove**
1. `Map -> Dynamic points(rm 1) + Static points(rm 1)`
2. `Static points(rm 1) -> Map`
3. `Map -> Dynamic points(rm 2) + Static points(rm 2)`
4. `Static points(rm 2) -> Map`
...

- `Dynamic points(rm 1) + Dynamic points(rm 2) + ... + Dynamic points(rm n)`を`RemoveDynamicMapGlobalResX???.pcd`として保存。
- `Static points(rm n)`を`RemoveStaticMapGlobalResX???.pcd`として保存。
- `Dynamic points(rm 1) + Dynamic points(rm 2) + ... + Dynamic points(rm n) -> Map` このMapをrevertで利用。

**2. revert**
1. `Map -> Dynamic points(rv 1) + Static points(rv 1)`
2. `Dynamic points(rv 1) -> Map`
3. `Map -> Dynamic points(rv 2) + Static points(rv 2)`
4. `Dynamic points(rv 2) -> Map`
...

- `Static points(rm n) + Static points(rv 1) + Static points(rv 2) + ... + Static points(rv n)`を`RevertStaticMapGlobalResX???.pcd`として保存。
- `Dynamic points(rv n)`を`RevertDynamicMapGlobalResX???.pcd`として保存。

<!-- この関数を変更したのでこの機能にも影響がある、など -->
<!--## Impact-->

<!-- どのような動作検証を行ったか -->
## Test
* [x] 竹芝でのrosbagで動作確認
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

<!--## Attention-->
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
