### PR TITLE
Feature/conditional map side operations

### DIFF
--- a/include/removert/Removerter.h
+++ b/include/removert/Removerter.h
@@ -119,6 +119,7 @@ public:
 
   void saveCurrentStaticAndDynamicPointCloudGlobal(bool _reverted = false);
   void saveCurrentStaticAndDynamicPointCloudLocal(int _base_pose_idx = 0, bool _reverted = false);
+  void readCurrentStaticAndDynamicPointCloudGlobal();
 
   // void local2global(const pcl::PointCloud<PointType>::Ptr& _ptcloud_global, pcl::PointCloud<PointType>::Ptr&
   // _ptcloud_local_to_save );

--- a/include/removert/RosParamServer.h
+++ b/include/removert/RosParamServer.h
@@ -60,6 +60,12 @@ public:
   //
   int kNumOmpCores;
 
+  // map-side removals
+  bool map_side_removals_;
+
+  // map-side reverts
+  bool map_side_reverts_;
+
   // scan-side removals
   bool scan_side_removals_;
   int kNumKnnPointsToCompare;

--- a/src/Removerter.cpp
+++ b/src/Removerter.cpp
@@ -995,37 +995,43 @@ void Removerter::run(void)
   bool reverted = false;
 
   // map-side removals
-  for (float _rm_res : remove_resolution_list_)
+  if (map_side_removals_)
   {
-    removeOnce(_rm_res);
+    for (float _rm_res : remove_resolution_list_)
+    {
+      removeOnce(_rm_res);
+    }
+
+    *output_map_global_static_ = *map_global_curr_static_;
+
+    // if you want to every iteration's map data, place below two lines to inside of the above for loop
+    saveCurrentStaticAndDynamicPointCloudGlobal(reverted);  // if you want to save within the global points uncomment this
+                                                            // line
+    saveCurrentStaticAndDynamicPointCloudLocal(base_node_idx_, reverted);  // w.r.t specific node's coord. 0 means w.r.t
+                                                                          // the start node, as an Identity.
   }
-
-  *output_map_global_static_ = *map_global_curr_static_;
-
-  // if you want to every iteration's map data, place below two lines to inside of the above for loop
-  saveCurrentStaticAndDynamicPointCloudGlobal(reverted);  // if you want to save within the global points uncomment this
-                                                          // line
-  saveCurrentStaticAndDynamicPointCloudLocal(base_node_idx_, reverted);  // w.r.t specific node's coord. 0 means w.r.t
-                                                                         // the start node, as an Identity.
 
   // map-side reverts
   // if you want to remove as much as possible, you can use omit this steps
-  map_global_curr_->clear();
-  *map_global_curr_ = *output_map_global_dynamic_;
-
-  for (float _rv_res : revert_resolution_list_)
+  if (map_side_reverts_)
   {
-    revertOnce(_rv_res);
+    map_global_curr_->clear();
+    *map_global_curr_ = *output_map_global_dynamic_;
+
+    for (float _rv_res : revert_resolution_list_)
+    {
+      revertOnce(_rv_res);
+    }
+
+    reverted = true;
+    *output_map_global_dynamic_ = *map_global_curr_dynamic_;
+
+    // if you want to every iteration's map data, place below two lines to inside of the above for loop
+    saveCurrentStaticAndDynamicPointCloudGlobal(reverted);  // if you want to save within the global points uncomment this
+                                                            // line
+    saveCurrentStaticAndDynamicPointCloudLocal(base_node_idx_, reverted);  // w.r.t specific node's coord. 0 means w.r.t
+                                                                          // the start node, as an Identity.
   }
-
-  reverted = true;
-  *output_map_global_dynamic_ = *map_global_curr_dynamic_;
-
-  // if you want to every iteration's map data, place below two lines to inside of the above for loop
-  saveCurrentStaticAndDynamicPointCloudGlobal(reverted);  // if you want to save within the global points uncomment this
-                                                          // line
-  saveCurrentStaticAndDynamicPointCloudLocal(base_node_idx_, reverted);  // w.r.t specific node's coord. 0 means w.r.t
-                                                                         // the start node, as an Identity.
 
   // scan-side removals
   map_global_curr_->clear();

--- a/src/RosParamServer.cpp
+++ b/src/RosParamServer.cpp
@@ -91,6 +91,12 @@ RosParamServer::RosParamServer() : nh(nh_super), ROSimg_transporter_(nh)
   nh.param<int>("removert/keyframe_gap", keyframe_gap_, 10);
   nh.param<float>("removert/keyframe_meter", keyframe_gap_meter_, 2.0);
 
+  // map-side removals
+  nh.param<bool>("removert/map_side_removals", map_side_removals_, true);
+
+  // map-side reverts
+  nh.param<bool>("removert/map_side_reverts", map_side_reverts_, true);
+
   // scan-side removals
   nh.param<bool>("removert/scan_side_removals", scan_side_removals_, true);
   nh.param<int>("removert/num_nn_points_within", kNumKnnPointsToCompare, 3);  // using higher, more strict static

--- a/src/removert_main.cpp
+++ b/src/removert_main.cpp
@@ -8,7 +8,9 @@ int main(int argc, char** argv)
   Removerter RMV;
   RMV.run();
 
-  ros::spin();
+  // ros::spin(); // TODO, for real-time integration (later)
+  ROS_INFO("\033[1;32m----> Removerter Done.\033[0m");
+  ros::shutdown();
 
   return 0;
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
以下2つのissueを解決します。
<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #7 
- fix #8  

<!-- 変更の詳細 -->
## Detail
- `removert/map_side_removals`と`removert/map_side_reverts`というROSパラメータを作り、removeとrevertの個別実行ができるように変更しました。
- 一連の処理後にromovertが終了したことを知らせるメッセージを出力します。また、`ros::shutdown()`によってノードを終了する処理を追加したため、launchファイル内の<node>タグで`required="true"`に設定すればCtrl+cをせずにlaunch内の全てのノードが停止します。

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
* [x] LIO-SAMを利用して作成した地図で動作確認 (ROS noetic)
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
- https://github.com/sbgisen/wheeltec_robot/pull/306 と同時にマージしていただきますようお願い致します。
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
